### PR TITLE
Disable `redirect_guess_404_permalink()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alleyvate is a collection of distinct features, each of which is enabled by defa
 
 This feature stops WordPress from attempting to guess a redirect URL for a 404 request. Its handle is `redirect_guess_shortcircuit`.
 
-The underlying behavior of `redirect_guess_404_permalink()` often confuses clients, and its raw database queries are non-performant on larger sites.
+The underlying behavior of `redirect_guess_404_permalink()` often confuses clients, and its database queries are non-performant on larger sites.
 
 ### User Enumeration Restrictions
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Alleyvate is a collection of distinct features, each of which is enabled by defa
 
 ## Features
 
+### Redirect-Guess Short-Circuit
+
+This feature stops WordPress from attempting to guess a redirect URL for a 404 request. Its handle is `redirect_guess_shortcircuit`.
+
+The underlying behavior of `redirect_guess_404_permalink()` often confuses clients, and its raw database queries are non-performant on larger sites.
+
 ### User Enumeration Restrictions
 
 This feature requires users to be logged in before accessing data about registered users that would otherwise be publicly accessible. Its handle is `user_enumeration_restrictions`.

--- a/src/alley/wp/alleyvate/feature/class-redirect-guess-shortcircuit.php
+++ b/src/alley/wp/alleyvate/feature/class-redirect-guess-shortcircuit.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Class file for Redirect_Guess_Shortcircuit
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Feature;
+
+use Alley\WP\Alleyvate\Internals\Feature;
+use Stringable;
+
+/**
+ * Disable `redirect_guess_404_permalink()`, whose behavior often confuses clients
+ * and is non-performant on larger sites.
+ */
+final class Redirect_Guess_Shortcircuit implements Feature {
+	/**
+	 * Feature handle.
+	 *
+	 * @return string|Stringable
+	 */
+	public function handle(): string|Stringable {
+		return 'redirect_guess_shortcircuit';
+	}
+
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_filter( 'do_redirect_guess_404_permalink', '__return_false' );
+	}
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -22,6 +22,7 @@ function load(): void {
 	 * @var Internals\Feature[] $features
 	 */
 	$features = [
+		new Feature\Redirect_Guess_Shortcircuit(),
 		new Feature\User_Enumeration_Restrictions(),
 	];
 

--- a/tests/alley/wp/alleyvate/test-redirect-guess-shortcircuit.php
+++ b/tests/alley/wp/alleyvate/test-redirect-guess-shortcircuit.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class file for Test_Redirect_Guess_Shortcircuit
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate;
+
+use Alley\WP\Alleyvate\Feature\Redirect_Guess_Shortcircuit;
+use Alley\WP\Alleyvate\Internals\Feature;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for short-circuiting the redirect URL guessing for 404 requests.
+ */
+final class Test_Redirect_Guess_Shortcircuit extends Test_Case {
+	/**
+	 * Feature instance.
+	 *
+	 * @var Feature
+	 */
+	private Feature $feature;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Redirect_Guess_Shortcircuit();
+	}
+
+	/**
+	 * Test that the feature short-circuits a redirect that would otherwise occur.
+	 */
+	public function test_no_redirect_guess() {
+		$post_name = 'foo';
+		$actual    = self::factory()->post->create(
+			[
+				'post_name' => $post_name,
+				'post_type' => 'post',
+			],
+		);
+
+		// Correct post name, incorrect post type.
+		$this->get(
+			add_query_arg(
+				[
+					'name'      => $post_name,
+					'post_type' => 'page',
+				],
+				'/',
+			),
+		);
+
+		// Redirect should be guessed before the feature is booted, but not after.
+		$this->assertSame( get_permalink( $actual ), redirect_guess_404_permalink() );
+		$this->feature->boot();
+		$this->assertFalse( redirect_guess_404_permalink() );
+	}
+}


### PR DESCRIPTION
## Summary

As titled. Closes #2.

## Notes for reviewers

None.

## Changelog entries

### Added

* Feature to disable `redirect_guess_404_permalink()`.

### Changed

### Deprecated

### Removed

### Fixed

### Security
