### PR TITLE
Bail if the Composer dependencies are not loaded to prevent a fatal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .php_cs.cache
 .phpunit.result.cache
 .php-cs-fixer.cache
+.vscode

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -16,6 +16,11 @@ namespace Alley\WP\Alleyvate;
  * Load plugin features.
  */
 function load(): void {
+	// Bail if the Alleyvate feature interface isn't loaded to prevent a fatal error.
+	if ( ! class_exists( Feature::class ) ) {
+		return;
+	}
+
 	/**
 	 * Features to load.
 	 *

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -17,7 +17,7 @@ namespace Alley\WP\Alleyvate;
  */
 function load(): void {
 	// Bail if the Alleyvate feature interface isn't loaded to prevent a fatal error.
-	if ( ! class_exists( Feature::class ) ) {
+	if ( ! interface_exists( Feature::class ) ) {
 		return;
 	}
 

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -27,9 +27,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Load Composer dependencies.
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
-} elseif ( ! class_exists( \Alley\WP\Alleyvate\Features\Redirect_Guess_Shortcircuit::class ) ) {
-	// Bail if the Composer dependencies aren't loaded to prevent a fatal.
-	return;
 }
 
 // Load the feature loader.

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -27,10 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Load Composer dependencies.
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
-}
-
-// Bail if the Composer dependencies aren't loaded to prevent a fatal.
-if ( ! class_exists( \Composer\InstalledVersions::class ) ) {
+} elseif ( ! class_exists( \Alley\WP\Alleyvate\Features\Redirect_Guess_Shortcircuit::class ) ) {
+	// Bail if the Composer dependencies aren't loaded to prevent a fatal.
 	return;
 }
 

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -30,7 +30,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 // Bail if the Composer dependencies aren't loaded to prevent a fatal.
-if ( ! function_exists( 'Alley\WP\Alleyvate\load' ) ) {
+if ( ! class_exists( \Composer\InstalledVersions::class ) ) {
 	return;
 }
 

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -29,6 +29,11 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
+// Bail if the Composer dependencies aren't loaded to prevent a fatal.
+if ( ! function_exists( 'Alley\WP\Alleyvate\load' ) ) {
+	return;
+}
+
 // Load the feature loader.
 require_once __DIR__ . '/src/alley/wp/alleyvate/load.php';
 


### PR DESCRIPTION
Ensure that the plugin does not fatal if Composer is not installed.