### PR TITLE
Disable Commenting functionality

### DIFF
--- a/src/alley/wp/alleyvate/features/class-disable-comments.php
+++ b/src/alley/wp/alleyvate/features/class-disable-comments.php
@@ -1,0 +1,98 @@
+<?php
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+
+class Disable_Comments implements Feature
+{
+    public function boot(): void
+    {
+        // Disable support for comments and trackbacks in post types
+        $this->disable_support();
+
+        // Close comments on the front-end
+        $this->close_comments();
+
+        // Hide existing comments
+        $this->hide_existing_comments();
+
+        // Remove comments page in menu
+        $this->remove_menu_pages();
+
+        // Redirect any user trying to access comments page
+        $this->redirect_comment_page();
+
+        // Remove comments icon from admin bar
+        $this->remove_admin_comment_icon();
+
+    }
+
+
+    /**
+     * Disable support for comments and trackbacks in post types.
+     */
+    private function disable_support()
+    {
+        add_action('admin_init', function() {
+            $post_types = get_post_types();
+            foreach ($post_types as $post_type) {
+                if (post_type_supports($post_type, 'comments')) {
+                    remove_post_type_support($post_type, 'comments');
+                    remove_post_type_support($post_type, 'trackbacks');
+                }
+            }
+        });
+    }
+
+    /**
+     * Close comments on the front-end.
+     */
+    private function close_comments()
+    {
+        add_filter('comments_open', '__return_false', 20, 2);
+        add_filter('pings_open', '__return_false', 20, 2);
+    }
+
+    /**
+     * Hide existing comments.
+     */
+    private function hide_existing_comments()
+    {
+        add_filter('comments_array', '__return_empty_array', 10, 2);
+    }
+
+    /**
+     * Remove comments page in menu.
+     */
+    private function remove_menu_pages()
+    {
+        add_action('admin_menu', function() {
+            remove_menu_page('edit-comments.php');
+        });
+    }
+
+    /**
+     * Redirect any user trying to access comments page.
+     */
+    private function redirect_comment_page()
+    {
+        add_action('admin_init', function() {
+            global $pagenow;
+
+            if ($pagenow === 'edit-comments.php') {
+                wp_redirect(admin_url());
+                exit;
+            }
+        });
+    }
+
+    /**
+     * Remove comments icon from admin bar.
+     */
+    private function remove_admin_comment_icon(): void
+    {
+        add_action( 'admin_bar_menu', function ( $wp_admin_bar ) {
+            $wp_admin_bar->remove_node( 'comments' );
+        }, 999 );
+    }
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -29,6 +29,7 @@ function load(): void {
 	$features = [
 		'redirect_guess_shortcircuit'   => new Features\Redirect_Guess_Shortcircuit(),
 		'user_enumeration_restrictions' => new Features\User_Enumeration_Restrictions(),
+		'disable_comments'              => new Features\Disable_Comments(),
 	];
 
 	foreach ( $features as $handle => $feature ) {

--- a/tests/alley/wp/alleyvate/features/test-disable-comments.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-comments.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Class file for Test_Disable_Comments
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for disabling comments.
+ */
+final class Test_Disable_Comments extends Test_Case {
+    /**
+     * Feature instance.
+     *
+     * @var Feature
+     */
+    private Feature $feature;
+
+    /**
+     * Set up.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->feature = new Disable_Comments();
+    }
+
+    /**
+     * Test that comments support is disabled for all post types.
+     */
+    public function test_comments_support_is_disabled() {
+        // Boot the feature
+        $this->feature->boot();
+
+        // Get all post types
+        $post_types = get_post_types();
+
+        // Loop over each post type and ensure that none supports comments
+        foreach ( $post_types as $post_type ) {
+            $this->assertFalse( post_type_supports( $post_type, 'comments' ) );
+        }
+    }
+
+    /**
+     * Test that comments are closed on the front-end.
+     */
+    public function test_comments_are_closed() {
+        // Create a sample post
+        $post_id = self::factory()->post->create();
+
+        // Boot the feature
+        $this->feature->boot();
+
+        // Ensure that comments are not open for this post
+        $this->assertFalse( comments_open( $post_id ) );
+    }
+
+    /**
+     * Test that existing comments are hidden.
+     */
+    public function test_existing_comments_are_hidden() {
+        // Create a sample post with a comment
+        $post_id = self::factory()->post->create();
+        self::factory()->comment->create(['comment_post_ID' => $post_id]);
+
+        // Boot the feature
+        $this->feature->boot();
+
+        // Ensure that there are no comments for this post
+        $this->assertEquals(0, wp_count_comments($post_id)->approved);
+    }
+
+    /**
+     * Test that the comments page is removed from the admin menu.
+     */
+    public function test_comments_page_is_removed() {
+        // Boot the feature
+        $this->feature->boot();
+
+        // Check if comments page link is in the admin menu
+        global $menu;
+        $found = false;
+        foreach($menu as $item) {
+            if($item[2] == 'edit-comments.php') {
+                $found = true;
+                break;
+            }
+        }
+
+        // Ensure that comments page link is not found in the admin menu
+        $this->assertFalse($found);
+    }
+
+    /**
+     * Test that any user trying to access comments page is redirected.
+     */
+    public function test_comment_page_access_is_redirected() {
+        // Boot the feature
+        $this->feature->boot();
+
+        // Try to access the comments page
+        try {
+            $this->get(admin_url('edit-comments.php'));
+        } catch (Exception $e) {
+            // Check if exception is 'Too many redirects'
+            $this->assertContains('Too many redirects', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

As titled. Should resolve #15 

## Notes for reviewers

Please forgive me. I know not what I do. Most/all of the tests are failing.

## Changelog entries

### Added

Disable_Comments class and Test_Disable_Comments

### Changed

load.php

## TODO:


From your questions, I assume that you are asking about how effective the Disable_Comments feature might be in terms of disabling all aspects of comments in WordPress. I'll evaluate based on what we have discussed so far:

Comments visible in FE in a core theme?
The feature should effectively hide existing comments and close comments on the front-end if it correctly applies filters to comments_open and pings_open. However, it won't hide existing comments on already loaded posts, this is something you may want to handle in the theme or through an additional filter.

Comments UI visible in admin? GB? admin bar?
The feature attempts to remove the comments page from the admin menu and the admin bar, and it redirects any user trying to access the comments page. However, the comments interface may still appear in the Gutenberg (GB) editor if the post type supports comments. This should be handled by remove_post_type_support() in the disable_support() function, but you need to ensure it runs for every public post type.

What about discussion settings?
The feature does not seem to disable or hide the Discussion settings page in the admin area. This could be an area of improvement for this feature.

Did you remove the comments rewrite rules?
This feature does not appear to address comment feed rewrite rules. This could be another area of improvement, as access to comment feed URLs could reveal comment information.

Did you remove the comments REST API endpoints?
No, the feature does not seem to address the REST API endpoints for comments. This is another potential area for improvement.

Comment data in REST API post responses?
The feature does not appear to modify REST API responses to exclude comment data. This could be another area of improvement.

Comment data in feeds?
Similar to the REST API endpoints and rewrite rules, the feature does not appear to address comments in feeds (both post comment feeds and the site-wide comment feed).

What about pings and trackbacks?
The feature appears to close pings along with comments on the front-end, but it doesn't appear to disable pingbacks or trackbacks at the server level.

From this self-assessment, it seems that the Disable_Comments feature does a decent job of disabling comments in several areas but does not comprehensively disable all aspects of the WordPress comments system. Depending on the specific needs of a site, this feature might be enough, but for a complete shutdown of all comment functionality, further development would be needed.


