### PR TITLE
Disable Sticky Posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
-Nothing yet.
+### Added
+
+* Added feature to disable sticky posts in WordPress.
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Alleyvate is a collection of distinct features, each of which is enabled by defa
 
 This feature disables WordPress comments entirely, including the ability to post, view, edit, list, count, modify settings for, or access URLs that are related to comments completely. Its handle is `disable_comments`.
 
+### Disable Sticky Posts
+
+This feature disables WordPress sticky posts entirely, including the ability to set and query sticky posts. Its handle is `disable_sticky_posts`.
+
 ### Disable Trackbacks
 
 This feature disables WordPress from sending or receiving trackbacks or pingbacks. Its handle is `disable_trackbacks`.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^1.0",
     "friendsofphp/php-cs-fixer": "^3.8",
-    "mantle-framework/testkit": "^0.9"
+    "mantle-framework/testkit": "^0.11"
   },
   "scripts": {
     "fixer": "php-cs-fixer -v fix --allow-risky=yes",

--- a/src/alley/wp/alleyvate/features/class-disable-sticky-posts.php
+++ b/src/alley/wp/alleyvate/features/class-disable-sticky-posts.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class file for Disable_Sticky_Posts
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+
+/**
+ * Fully disables sticky posts.
+ */
+final class Disable_Sticky_Posts implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_filter( 'pre_option_sticky_posts', '__return_empty_array', 9999 );
+		add_filter( 'is_sticky', '__return_false', 9999 );
+		add_action( 'admin_head', [ $this, 'on_admin_head' ] );
+		add_filter( 'rest_prepare_post', [ $this, 'on_rest_prepare_post' ], 9999 );
+	}
+
+	/**
+	 * Remove sticky posts from the admin edit screen.
+	 */
+	public function on_admin_head(): void {
+		?>
+		<style>
+			.wp-admin #sticky-span {
+				display: none !important;
+			}
+		</style>
+
+		<script>
+			document.addEventListener('DOMContentLoaded', function() {
+				var checkbox = document.querySelector('input[name="sticky"]');
+
+				if (checkbox) {
+					checkbox.parentNode.parentNode.removeChild(checkbox.parentNode);
+				}
+			});
+		</script>
+		<?php
+	}
+
+	/**
+	 * Filters a REST response to make it look like the user can't stick posts.
+	 *
+	 * @see \gutenberg_add_target_schema_to_links().
+	 *
+	 * @param \WP_REST_Response $response The response object.
+	 * @return \WP_REST_Response Updated respose.
+	 */
+	public function on_rest_prepare_post( $response ) {
+		$response->remove_link( 'https://api.w.org/action-sticky' );
+
+		return $response;
+	}
+}

--- a/src/alley/wp/alleyvate/features/class-disable-sticky-posts.php
+++ b/src/alley/wp/alleyvate/features/class-disable-sticky-posts.php
@@ -30,11 +30,15 @@ final class Disable_Sticky_Posts implements Feature {
 
 	/**
 	 * Remove sticky posts from the admin edit screen.
+	 *
+	 * Includes a script to remove the checkbox from the quick edit screen that
+	 * will cover the browsers that :has is not supported in yet.
 	 */
 	public function on_admin_head(): void {
 		?>
 		<style>
-			.wp-admin #sticky-span {
+			.wp-admin #sticky-span,
+			label:has(input[name="sticky"]) {
 				display: none !important;
 			}
 		</style>

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -28,6 +28,7 @@ function load(): void {
 	 */
 	$features = [
 		'disable_comments'              => new Features\Disable_Comments(),
+		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
 		'disable_trackbacks'            => new Features\Disable_Trackbacks(),
 		'disallow_file_edit'            => new Features\Disallow_File_Edit(),
 		'redirect_guess_shortcircuit'   => new Features\Redirect_Guess_Shortcircuit(),

--- a/tests/alley/wp/alleyvate/features/test-disable-comments.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-comments.php
@@ -19,7 +19,8 @@ use Mantle\Testkit\Test_Case;
  * Tests for fully disabling comment functionality.
  */
 final class Test_Disable_Comments extends Test_Case {
-	use \Mantle\Testing\Concerns\Admin_Screen;
+	use \Mantle\Testing\Concerns\Admin_Screen,
+		\Mantle\Testing\Concerns\Refresh_Database;
 
 	/**
 	 * Feature instance.

--- a/tests/alley/wp/alleyvate/features/test-disable-sticky-posts.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-sticky-posts.php
@@ -44,8 +44,8 @@ final class Test_Disable_Sticky_Posts extends Test_Case {
 	 */
 	public function test_disable_sticky_posts_in_query() {
 
-		$posts         = $this->factory()->post->create_ordered_set( 5 );
-		$stick_post_id = $this->factory()->post->create(
+		$posts         = static::factory()->post->create_ordered_set( 5 );
+		$stick_post_id = static::factory()->post->create(
 			[
 				'post_date' => '2019-01-01 00:00:00',
 			]
@@ -90,11 +90,7 @@ final class Test_Disable_Sticky_Posts extends Test_Case {
 	public function test_disable_action_sticky_rest_api_edit() {
 		$this->acting_as( 'administrator' );
 
-		$post_id = $this->factory()->post->create(
-			[
-				'post_date' => '2019-01-01 00:00:00',
-			]
-		);
+		$post_id = static::factory()->post->create();
 
 		$this->get(
 			rest_url( 'wp/v2/posts/' . $post_id . '?context=edit' ),

--- a/tests/alley/wp/alleyvate/features/test-disable-sticky-posts.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-sticky-posts.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Class file for Test_Disable_Sticky_Posts
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+use Mantle\Testing\Concerns\Refresh_Database;
+use Mantle\Testkit\Test_Case;
+use WP_Query;
+
+/**
+ * Tests for fully disabling sticky posts.
+ */
+final class Test_Disable_Sticky_Posts extends Test_Case {
+	use Refresh_Database;
+
+	/**
+	 * Feature to test.
+	 *
+	 * @var Disable_Sticky_Posts
+	 */
+	protected Disable_Sticky_Posts $feature;
+
+	/**
+	 * Setup the test case.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Disable_Sticky_Posts();
+	}
+
+	/**
+	 * Test that sticky posts are disabled in queries on the homepage.
+	 */
+	public function test_disable_sticky_posts_in_query() {
+
+		$posts         = $this->factory()->post->create_ordered_set( 5 );
+		$stick_post_id = $this->factory()->post->create(
+			[
+				'post_date' => '2019-01-01 00:00:00',
+			]
+		);
+
+		stick_post( $stick_post_id );
+
+		$this->assertTrue( is_sticky( $stick_post_id ) );
+
+		// Make a request to the homepage and inspect the query.
+		$this->get( '/' );
+
+		$this->assertCount( 6, $GLOBALS['wp_query']->posts );
+		$this->assertEquals( $stick_post_id, $GLOBALS['wp_query']->posts[0]->ID );
+
+		// Activate the disable sticky post feature.
+		$this->feature->boot();
+
+		// The post should no longer be considered sticky.
+		$this->assertFalse( is_sticky( $stick_post_id ) );
+
+		// Make another request to the homepage and inspect the query.
+		$this->get( '/' );
+
+		$this->assertCount( 6, $GLOBALS['wp_query']->posts );
+		$this->assertNotEquals( $stick_post_id, $GLOBALS['wp_query']->posts[0]->ID );
+
+		// Ensure that the post order is correct (i.e. the sticky post is at the
+		// end and the ordered set is in the proper order after it).
+		$this->assertEquals(
+			[
+				...array_reverse( $posts ),
+				$stick_post_id,
+			],
+			array_column( $GLOBALS['wp_query']->posts, 'ID' ),
+		);
+	}
+
+	/**
+	 * Test that sticky posts are disabled in Gutenberg.
+	 */
+	public function test_disable_action_sticky_rest_api_edit() {
+		$this->acting_as( 'administrator' );
+
+		$post_id = $this->factory()->post->create(
+			[
+				'post_date' => '2019-01-01 00:00:00',
+			]
+		);
+
+		$this->get(
+			rest_url( 'wp/v2/posts/' . $post_id . '?context=edit' ),
+		)
+				->assertJsonPathExists( '_links.wp:action-sticky' );
+
+		// Activate the disable sticky post feature.
+		$this->feature->boot();
+
+		$this->get(
+			rest_url( 'wp/v2/posts/' . $post_id . '?context=edit' ),
+		)
+				->assertJsonPathMissing( '_links.wp:action-sticky' );
+	}
+}


### PR DESCRIPTION
## Summary

Disable sticky posts in the admin for both the classic editor and Gutenberg.

Added `Refresh_Database` trait to Disable Comments test because of an error in Mantle that will need fixing:

```
Alley\WP\Alleyvate\Features\Test_Disable_Sticky_Posts::test_disable_action_sticky_rest_api_edit
Mantle\Database\Model\Model_Exception: Error saving model: Sorry, that username already exists!
```

Resolves #41.

## Notes for reviewers

The tests for this had to be written to inspect the homepage query versus making a raw `WP_Query` because sticky posts are only applied on the homepage.

## Changelog entries

### Added

* Added feature to disable sticky posts in WordPress.

### Changed

### Deprecated

### Removed

### Fixed

### Security
