### PR TITLE
Remove Selected Admin Bar Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ add_filter( 'alleyvate_load_disable_comments', '__return_false' );
 
 Each feature's handle is listed below, along with a description of what it does.
 
+### `clean_admin_bar`
+
+This feature removes selected nodes from the admin bar.
+
 ### `disable_comments`
 
 This feature disables WordPress comments entirely, including the ability to post, view, edit, list, count, modify settings for, or access URLs that are related to comments completely.
 
 ### `disable_dashboard_widgets`
 
-This feature removes clutter from the dashboard. Its handle is `dashboard_widget_removal`.
+This feature removes clutter from the dashboard.
 
 ### `disable_sticky_posts`
 

--- a/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
+++ b/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class file for Clean_Admin_Bar
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+
+/**
+ * Cleans admin bar.
+ */
+final class Clean_Admin_Bar implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_filter( 'wp_before_admin_bar_render', [ $this, 'before_admin_bar_render' ], 9999 );
+	}
+
+	/**
+	 * Set menus to be disabled.
+	 *
+	 * @return mixed|void
+	 */
+	public function menus() {
+		$default_menus = [
+			'comments',
+			'customize',
+			'themes',
+			'wp-seo-menu', // Yoast.
+		];
+
+		return apply_filters( 'alleyvate_clean_admin_bar_menus', $default_menus );
+	}
+
+	/**
+	 * Disables specified menus in admin bar.
+	 *
+	 * @return void
+	 */
+	public function before_admin_bar_render() {
+		global $wp_admin_bar;
+		foreach ( $this->menus() as $menu ) {
+			$wp_admin_bar->remove_menu( $menu );
+		}
+	}
+}

--- a/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
+++ b/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
@@ -22,25 +22,7 @@ final class Clean_Admin_Bar implements Feature {
 	 * Boot the feature.
 	 */
 	public function boot(): void {
-		add_filter( 'wp_before_admin_bar_render', [ $this, 'before_admin_bar_render' ], 9999 );
-	}
-
-	/**
-	 * Set menus to be disabled.
-	 *
-	 * @return mixed|void
-	 */
-	public function menus() {
-		$default_menus = [
-			'comments',
-			'customize',
-			'gform-forms', // Gravity forms noise
-			'notes',
-			'themes',
-			'wp-seo-menu', // Yoast noise
-		];
-
-		return apply_filters( 'alleyvate_clean_admin_bar_menus', $default_menus );
+		add_action( 'wp_before_admin_bar_render', [ $this, 'before_admin_bar_render' ], 9999 );
 	}
 
 	/**
@@ -49,9 +31,28 @@ final class Clean_Admin_Bar implements Feature {
 	 * @return void
 	 */
 	public function before_admin_bar_render() {
+
 		global $wp_admin_bar;
-		foreach ( $this->menus() as $menu ) {
-			$wp_admin_bar->remove_menu( $menu );
+
+		$current_nodes = $wp_admin_bar->get_nodes();
+		foreach ( $this->get_disposable_nodes() as $node ) {
+			$wp_admin_bar->remove_menu( $node );
 		}
+	}
+
+	/**
+	 * Set menus to be disabled.
+	 *
+	 * @return mixed|void
+	 */
+	public function get_disposable_nodes() {
+		$disposable_nodes = [
+			'comments',
+			//'customize',
+			//'notes',
+			'themes',
+		];
+
+		return apply_filters( 'alleyvate_clean_admin_bar_menus', $disposable_nodes );
 	}
 }

--- a/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
+++ b/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
@@ -31,10 +31,8 @@ final class Clean_Admin_Bar implements Feature {
 	 * @return void
 	 */
 	public function before_admin_bar_render() {
-
 		global $wp_admin_bar;
 
-		$current_nodes = $wp_admin_bar->get_nodes();
 		foreach ( $this->get_disposable_nodes() as $node ) {
 			$wp_admin_bar->remove_menu( $node );
 		}
@@ -49,6 +47,8 @@ final class Clean_Admin_Bar implements Feature {
 		$disposable_nodes = [
 			'comments',
 			'themes',
+			'updates',
+			'wp-logo',
 		];
 
 		return apply_filters( 'alleyvate_clean_admin_bar_menus', $disposable_nodes );

--- a/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
+++ b/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
@@ -48,8 +48,6 @@ final class Clean_Admin_Bar implements Feature {
 	public function get_disposable_nodes() {
 		$disposable_nodes = [
 			'comments',
-			//'customize',
-			//'notes',
 			'themes',
 		];
 

--- a/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
+++ b/src/alley/wp/alleyvate/features/class-clean-admin-bar.php
@@ -34,8 +34,10 @@ final class Clean_Admin_Bar implements Feature {
 		$default_menus = [
 			'comments',
 			'customize',
+			'gform-forms', // Gravity forms noise
+			'notes',
 			'themes',
-			'wp-seo-menu', // Yoast.
+			'wp-seo-menu', // Yoast noise
 		];
 
 		return apply_filters( 'alleyvate_clean_admin_bar_menus', $default_menus );

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -28,7 +28,7 @@ function load(): void {
 	 */
 	$features = [
 		'clean_admin_bar'               => new Features\Clean_Admin_Bar(),
-		'disable_comments'              => new Features\Disable_Comments(),
+		//'disable_comments'              => new Features\Disable_Comments(),
 		'disable_dashboard_widgets'     => new Features\Disable_Dashboard_Widgets(),
 		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
 		'disable_trackbacks'            => new Features\Disable_Trackbacks(),

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -27,6 +27,7 @@ function load(): void {
 	 * @var Feature[] $features
 	 */
 	$features = [
+		'clean_admin_bar'               => new Features\Clean_Admin_Bar(),
 		'disable_comments'              => new Features\Disable_Comments(),
 		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
 		'disable_trackbacks'            => new Features\Disable_Trackbacks(),

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -28,7 +28,7 @@ function load(): void {
 	 */
 	$features = [
 		'clean_admin_bar'               => new Features\Clean_Admin_Bar(),
-		//'disable_comments'              => new Features\Disable_Comments(),
+		'disable_comments'              => new Features\Disable_Comments(),
 		'disable_dashboard_widgets'     => new Features\Disable_Dashboard_Widgets(),
 		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
 		'disable_trackbacks'            => new Features\Disable_Trackbacks(),

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -16,9 +16,9 @@ use Alley\WP\Alleyvate\Feature;
 use Mantle\Testkit\Test_Case;
 
 /**
- * Tests for the disallowing of file editing.
+ * Tests for the cleaning of the admin bar.
  */
-final class Test_Disallow_File_Edit extends Test_Case {
+final class Test_Clean_Admin_Bar extends Test_Case {
 	/**
 	 * Feature instance.
 	 *
@@ -32,13 +32,15 @@ final class Test_Disallow_File_Edit extends Test_Case {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->feature = new Disallow_File_Edit();
+		$this->feature = new Clean_Admin_Bar();
 	}
 
 	/**
 	 * Test that the feature disallows file editing.
 	 */
-	public function test_disallow_file_editing() {
+	public function test_clean_admin_bar() {
+		global $wp_admin_bar;
+
 		$this->assertFalse( \defined( 'DISALLOW_FILE_EDIT' ), 'DISALLOW_FILE_EDIT should not be defined prior to boot.' );
 		$this->feature->boot();
 		$this->assertTrue( \defined( 'DISALLOW_FILE_EDIT' ), 'DISALLOW_FILE_EDIT should be defined after boot.' );

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -112,10 +112,5 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 
 		return $wp_admin_bar;
 	}
-
-
-
-
+	
 }
-
-

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -48,7 +48,7 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 		$disposable_nodes = $this->feature->get_disposable_nodes();
 		$current_nodes    = $admin_bar->get_nodes();
 
-		// Let's make sure they are there before we remove them.
+		// Let's make sure the nodes exist before we remove them.
 		foreach ( $disposable_nodes as $disposable_node ) {
 			// Updates will not exist in a test context.
 			if ( 'updates' === $disposable_node ) {
@@ -77,7 +77,7 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 	public function test_filter() {
 
 		$admin_bar = $this->apply_admin_bar();
-		$node      = 'comments';
+		$node      = 'my-account';
 
 		add_filter(
 			'alleyvate_clean_admin_bar_menus',
@@ -87,6 +87,12 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 				return $disposable_nodes;
 			}
 		);
+
+		// Get nodes to compare.
+		$current_nodes = $admin_bar->get_nodes();
+
+		// Let's make sure the node exists before we remove it.
+		$this->assertArrayHasKey( $node, $current_nodes, 'The filtered node ' . $node . ' should exist in $wp_admin_bar global prior to boot.' );
 
 		// Boot feature.
 		$this->feature->boot();

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -19,6 +19,8 @@ use Mantle\Testkit\Test_Case;
  * Tests for the cleaning of the admin bar.
  */
 final class Test_Clean_Admin_Bar extends Test_Case {
+	use \Mantle\Testing\Concerns\Refresh_Database;
+
 	/**
 	 * Feature instance.
 	 *
@@ -27,23 +29,50 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 	private Feature $feature;
 
 	/**
+	 * Test that the feature disallows file editing.
+	 */
+	public function test_clean_admin_bar() {
+
+		// Load file required to work with the admin bar.
+		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+
+		// Set role.
+		$this->acting_as( 'administrator' );
+
+		// Make admin bar go.
+		global $wp_admin_bar;
+		_wp_admin_bar_init();
+		do_action_ref_array( 'admin_bar_menu', [ &$wp_admin_bar ] );
+
+		// Get nodes to compare.
+		$disposable_nodes = $this->feature->get_disposable_nodes();
+		$current_nodes    = $wp_admin_bar->get_nodes();
+
+		// Let's make sure they are there before we remove them.
+		foreach ( $disposable_nodes as $disposable_node ) {
+			$this->assertArrayHasKey( $disposable_node, $current_nodes, $disposable_node . ' should exist in $wp_admin_bar prior to boot.' );
+		}
+
+		// Boot feature.
+		$this->feature->boot();
+		do_action( 'wp_before_admin_bar_render' );
+
+		// Get updated set of nodes.
+		$current_nodes    = $wp_admin_bar->get_nodes();
+
+		// Compare again.
+		foreach ( $disposable_nodes as $disposable_node ) {
+			$this->assertArrayNotHasKey( $disposable_node, $current_nodes, $disposable_node . ' should not exist in $wp_admin_bar after boot.' );
+		}
+
+	}
+
+	/**
 	 * Set up.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->feature = new Clean_Admin_Bar();
-	}
-
-	/**
-	 * Test that the feature disallows file editing.
-	 */
-	public function test_clean_admin_bar() {
-		global $wp_admin_bar;
-
-		$this->assertFalse( \defined( 'DISALLOW_FILE_EDIT' ), 'DISALLOW_FILE_EDIT should not be defined prior to boot.' );
-		$this->feature->boot();
-		$this->assertTrue( \defined( 'DISALLOW_FILE_EDIT' ), 'DISALLOW_FILE_EDIT should be defined after boot.' );
-		$this->assertTrue( DISALLOW_FILE_EDIT );
 	}
 }

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -50,6 +50,10 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 
 		// Let's make sure they are there before we remove them.
 		foreach ( $disposable_nodes as $disposable_node ) {
+			// Updates will not exist in a test context.
+			if ( 'updates' === $disposable_node ) {
+				continue;
+			}
 			$this->assertArrayHasKey( $disposable_node, $current_nodes, $disposable_node . ' should exist in $wp_admin_bar global prior to boot.' );
 		}
 
@@ -73,8 +77,8 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 	public function test_filter() {
 
 		$admin_bar = $this->apply_admin_bar();
+		$node      = 'comments';
 
-		$node = 'comments';
 		add_filter(
 			'alleyvate_clean_admin_bar_menus',
 			function ( $disposable_nodes ) use ( $node ) {
@@ -112,5 +116,5 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 
 		return $wp_admin_bar;
 	}
-	
+
 }

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class file for Test_Clean_Admin_Bar
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for the disallowing of file editing.
+ */
+final class Test_Disallow_File_Edit extends Test_Case {
+	/**
+	 * Feature instance.
+	 *
+	 * @var Feature
+	 */
+	private Feature $feature;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Disallow_File_Edit();
+	}
+
+	/**
+	 * Test that the feature disallows file editing.
+	 */
+	public function test_disallow_file_editing() {
+		$this->assertFalse( \defined( 'DISALLOW_FILE_EDIT' ), 'DISALLOW_FILE_EDIT should not be defined prior to boot.' );
+		$this->feature->boot();
+		$this->assertTrue( \defined( 'DISALLOW_FILE_EDIT' ), 'DISALLOW_FILE_EDIT should be defined after boot.' );
+		$this->assertTrue( DISALLOW_FILE_EDIT );
+	}
+}

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -29,9 +29,9 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 	private Feature $feature;
 
 	/**
-	 * Test that the feature disallows file editing.
+	 * Test admin bar cleaning.
 	 */
-	public function test_clean_admin_bar() {
+	public function test_clean_admin_bar() { // // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
 
 		// Load file required to work with the admin bar.
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
@@ -42,7 +42,7 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 		// Make admin bar go.
 		global $wp_admin_bar;
 		_wp_admin_bar_init();
-		do_action_ref_array( 'admin_bar_menu', [ &$wp_admin_bar ] );
+		do_action_ref_array( 'admin_bar_menu', [ &$wp_admin_bar ] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		// Get nodes to compare.
 		$disposable_nodes = $this->feature->get_disposable_nodes();
@@ -55,10 +55,10 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 
 		// Boot feature.
 		$this->feature->boot();
-		do_action( 'wp_before_admin_bar_render' );
+		do_action( 'wp_before_admin_bar_render' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		// Get updated set of nodes.
-		$current_nodes    = $wp_admin_bar->get_nodes();
+		$current_nodes = $wp_admin_bar->get_nodes();
 
 		// Compare again.
 		foreach ( $disposable_nodes as $disposable_node ) {


### PR DESCRIPTION
## Summary

Removes specific admin bar links that we don't normally want to include (comments and themes).

## Changelog entries

### Added

Added the `clean_admin_bar` feature.

Fixes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Introduced the "Clean Admin Bar" feature in WordPress. This update enhances the user interface by decluttering the admin bar, removing specified menus for a cleaner, more intuitive experience.
- Test: Added comprehensive test cases for the new "Clean Admin Bar" feature, ensuring its functionality and reliability.
- Documentation: Updated the README file, removing the handle for the now obsolete `disable_dashboard_widgets` feature for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->