### PR TITLE
Issue-49: Add nonce to wp-login

### DIFF
--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -76,19 +76,8 @@ final class Login_Nonce implements Feature {
 	 * Initializes the nonce fields. Is only run on `login_init` to restrict nonce data to login page.
 	 */
 	public function initialize_nonce_fields(): void {
-		/**
-		 * Filters the nonce name.
-		 *
-		 * @param string $nonce_name The nonce name.
-		 */
-		$this->nonce_name = (string) apply_filters( 'alleyvate_nonce_name', $this->generate_random_nonce_name( 'alleyvate_login_nonce' ) );
-
-		/**
-		 * Filters the nonce action name.
-		 *
-		 * @param string $nonce_action The action name.
-		 */
-		$this->nonce_action = (string) apply_filters( 'alleyvate_nonce_action', 'alleyvate_login_action' );
+		$this->nonce_name   = $this->generate_random_nonce_name( 'alleyvate_login_nonce' );
+		$this->nonce_action = 'alleyvate_login_action';
 
 		/**
 		 * Filters the lifetime of the nonce, in minutes.

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -189,6 +189,6 @@ final class Login_Nonce implements Feature {
 				$parts[] = "{$key}={$value}";
 			}
 		}
-		return \hash( 'sha256', implode( '-', $parts ) );
+		return hash( 'sha256', implode( '-', $parts ) );
 	}
 }

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -34,7 +34,7 @@ final class Login_Nonce implements Feature {
 	private string $nonce_action;
 
 	/**
-	 * The nonce lifetime, in minutes.
+	 * The nonce lifetime. Stored in seconds.
 	 *
 	 * @var int
 	 */
@@ -88,6 +88,8 @@ final class Login_Nonce implements Feature {
 
 		/**
 		 * Filters the lifetime of the nonce, in minutes.
+		 *
+		 * Converted to seconds before storage.
 		 *
 		 * @param int $timeout The lifetime of the nonce, in minutes. Default 30.
 		 */

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -35,14 +35,14 @@ final class Login_Nonce implements Feature {
 	 *
 	 * @var string
 	 */
-	private const NONCE_ACTION = 'alleyvate_login_action';
+	public const NONCE_ACTION = 'alleyvate_login_action';
 
 	/**
 	 * The nonce lifetime. Stored in seconds.
 	 *
 	 * @var int
 	 */
-	private const NONCE_TIMEOUT = 1800;
+	public const NONCE_TIMEOUT = 1800;
 
 	/**
 	 * Boot the feature.
@@ -65,7 +65,7 @@ final class Login_Nonce implements Feature {
 	 * Add the nonce field to the form.
 	 */
 	public static function action__add_nonce_to_form(): void {
-		wp_nonce_field( self::NONCE_ACTION, self::generate_random_nonce_name( self::NONCE_SALT ) );
+		wp_nonce_field( self::NONCE_ACTION, self::generate_random_nonce_name() );
 	}
 
 	/**
@@ -103,8 +103,8 @@ final class Login_Nonce implements Feature {
 		add_filter( 'nonce_life', $nonce_life_filter );
 
 		$nonce = false;
-		if ( ! empty( $_POST[ self::generate_random_nonce_name( self::NONCE_SALT ) ] ) ) {
-			$nonce = sanitize_key( $_POST[ self::generate_random_nonce_name( self::NONCE_SALT ) ] );
+		if ( ! empty( $_POST[ self::generate_random_nonce_name() ] ) ) {
+			$nonce = sanitize_key( $_POST[ self::generate_random_nonce_name() ] );
 		}
 
 		if (
@@ -113,7 +113,8 @@ final class Login_Nonce implements Feature {
 		) {
 			// This is a login with an invalid nonce. Throw an error.
 			http_response_code( 403 );
-			die;
+			wp_die();
+			return;
 		}
 
 		/*
@@ -128,8 +129,8 @@ final class Login_Nonce implements Feature {
 	 * @param string $name The salt value.
 	 * @return string
 	 */
-	public static function generate_random_nonce_name( string $name ): string {
-		$parts = [ $name ];
+	public static function generate_random_nonce_name(): string {
+		$parts = [ self::NONCE_SALT ];
 		if ( ! empty( $_SERVER ) ) { // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 			foreach ( [ 'REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP' ] as $key ) {
 				$value   = ! empty( $_SERVER[ $key ] ) ? sanitize_key( $_SERVER[ $key ] ) : '';

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -126,7 +126,6 @@ final class Login_Nonce implements Feature {
 	/**
 	 * Randomize the nonce name using the data from the $_SERVER super global, and a provided salt.
 	 *
-	 * @param string $name The salt value.
 	 * @return string
 	 */
 	public static function generate_random_nonce_name(): string {

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -176,7 +176,7 @@ final class Login_Nonce implements Feature {
 	 * @param string $name The salt value.
 	 * @return string
 	 */
-	private function generate_random_nonce_name( string $name ): string {
+	public function generate_random_nonce_name( string $name ): string {
 		$parts = [ $name ];
 		if ( ! empty( $_SERVER ) ) { // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
 			foreach ( [ 'REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP' ] as $key ) {

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class file for Login_Nonce
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+
+/**
+ *
+ */
+final class Login_Nonce implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+
+	}
+}

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -58,7 +58,7 @@ final class Login_Nonce implements Feature {
 	 * Add a meta refresh to the login page, so it will refresh after the nonce timeout.
 	 */
 	public static function action__add_meta_refresh(): void {
-		echo sprintf( '<meta http-equiv="refresh" content="%d">', esc_attr( self::NONCE_TIMEOUT ) );
+		printf( '<meta http-equiv="refresh" content="%d">', esc_attr( self::NONCE_TIMEOUT ) );
 	}
 
 	/**

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -15,13 +15,155 @@ namespace Alley\WP\Alleyvate\Features;
 use Alley\WP\Alleyvate\Feature;
 
 /**
- *
+ * Adds a nonce field to the login form.
  */
 final class Login_Nonce implements Feature {
+
+	/**
+	 * The name to use for the nonce.
+	 *
+	 * @var string
+	 */
+	private string $nonce_name;
+
+	/**
+	 * The action to use for the nonce.
+	 *
+	 * @var string
+	 */
+	private string $nonce_action;
+
+	/**
+	 * The nonce lifetime, in minutes.
+	 *
+	 * @var int
+	 */
+	private int $nonce_timeout;
+
 	/**
 	 * Boot the feature.
 	 */
 	public function boot(): void {
+		add_action( 'login_init', [$this, 'initialize_nonce_fields'] );
+		add_action( 'login_head', [$this, 'add_meta_refresh'] );
+		add_action( 'login_form', [$this, 'add_nonce_to_form'] );
+		add_filter( 'authenticate', [$this, 'validate_login_nonce'], 9999, 3 );
+	}
 
+	public function add_meta_refresh(): void {
+		if ( ! ( (bool) apply_filters( 'alleyvate_nonce_meta_refresh', true ) ) ) {
+			return;
+		}
+
+		echo sprintf( '<meta http-equiv="refresh" content="%d">', $this->nonce_timeout );
+	}
+
+	public function add_nonce_to_form(): void {
+		wp_nonce_field( $this->nonce_action, $this->nonce_name );
+	}
+
+	public function initialize_nonce_fields(): void {
+		/**
+		 * Filters the nonce name.
+		 *
+		 * @param string $nonce_name The nonce name.
+		 */
+		$this->nonce_name    = (string) apply_filters( 'alleyvate_nonce_name', $this->generate_random_nonce_name('alleyvate_login_nonce') );
+
+		/**
+		 * Filters the nonce action name.
+		 *
+		 * @param string $nonce_action The action name.
+		 */
+		$this->nonce_action  = (string) apply_filters( 'alleyvate_nonce_action', 'alleyvate_login_action' );
+
+		/**
+		 * Filters the lifetime of the nonce, in minutes.
+		 *
+		 * @param int $timeout The lifetime of the nonce, in minutes. Default 30.
+		 */
+		$this->nonce_timeout = ((int) apply_filters( 'alleyvate_nonce_timeout', 30 )) * 60;
+
+		add_filter( 'nonce_life', fn() => $this->nonce_timeout );
+	}
+
+	/**
+	 * Validates the passed nonce is valid. Returns a user object on valid login,
+	 * or void on invalid nonce.
+	 *
+	 * @param \WP_User|\WP_Error|null $user The result of previous login validations. An instance of
+	 *                    WP_User if all validations have passed previously.
+	 */
+	public function validate_login_nonce($user, $username, $password) {
+
+		/*
+		 * If the filter is returning a \WP_Error, then validation has already failed.
+		 * No need to check the nonce.
+		 */
+		if ( $user instanceof \WP_Error ) {
+			return $user;
+		}
+
+		/*
+		 * We can't be sure when this filter will be triggered. Since we always need
+		 * this filter triggered last, in the case of `$user` coming through as null
+		 * lets run authentications again, and make sure.
+		 *
+		 * In a perfect world, this block will never run, but if it needs to be run,
+		 * we want it to run.
+		 */
+		if ( null === $user ) {
+			// Remove this check to avoid infinite loops.
+			remove_filter( 'authenticate', [$this, 'validate_login_nonce'], 9999);
+			$user = apply_filters( 'authenticate', $user, $username, $password );
+		}
+
+		// We're sure about this value now. Exit early.
+		if ( ! $user instanceof \WP_User ) {
+			return $user;
+		}
+
+		/*
+		 * Now that we've manually run all of the authentication filters,
+		 * and we know we have a valid login attempt, remove all the filters
+		 * so we don't risk bypassing our nonce validation down the line.
+		 */
+		remove_all_filters( 'authenticate' );
+
+		// If no post data exists, no nonce data exists, which means our login is invalid.
+		if ( empty( $_POST ) ) {
+			return;
+		}
+
+		$nonce = $_POST[ $this->nonce_name ] ?? false;
+
+		if ( ! $nonce ) {
+			return null;
+		}
+
+		$nonce_validation = wp_verify_nonce($nonce, $this->nonce_action);
+
+		if ( ! $nonce_validation ) {
+			return null;
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Randomize the nonce name using the data from the $_SERVER super global, and a provided salt.
+	 *
+	 * @param string $name The salt value.
+	 * @return string
+	 */
+	private function generate_random_nonce_name( string $name ): string {
+		$parts = [$name];
+		if ( ! empty( $_SERVER ) ) {
+			foreach (['REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP'] as $key ) {
+				$value = ! empty( $_SERVER[ $key ] ) ? $_SERVER[ $key ] : '';
+				$parts[] = "{$key}={$value}";
+			}
+		}
+		return \hash('sha256', implode('-', $parts));
 	}
 }

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -16,6 +16,10 @@ use Alley\WP\Alleyvate\Feature;
 
 /**
  * Adds a nonce field to the login form.
+ *
+ * Heavily inspired by `wp-login-nonce` by `elyobo`
+ *
+ * @link https://github.com/elyobo/wp-login-nonce
  */
 final class Login_Nonce implements Feature {
 

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -44,45 +44,54 @@ final class Login_Nonce implements Feature {
 	 * Boot the feature.
 	 */
 	public function boot(): void {
-		add_action( 'login_init', [$this, 'initialize_nonce_fields'] );
-		add_action( 'login_head', [$this, 'add_meta_refresh'] );
-		add_action( 'login_form', [$this, 'add_nonce_to_form'] );
-		add_filter( 'authenticate', [$this, 'validate_login_nonce'], 9999, 3 );
+		add_action( 'login_init', [ $this, 'initialize_nonce_fields' ] );
+		add_action( 'login_head', [ $this, 'add_meta_refresh' ] );
+		add_action( 'login_form', [ $this, 'add_nonce_to_form' ] );
+		add_filter( 'authenticate', [ $this, 'validate_login_nonce' ], 9999, 3 );
 	}
 
+	/**
+	 * Add a meta refresh to the login page, so it will refresh after the nonce timeout.
+	 */
 	public function add_meta_refresh(): void {
 		if ( ! ( (bool) apply_filters( 'alleyvate_nonce_meta_refresh', true ) ) ) {
 			return;
 		}
 
-		echo sprintf( '<meta http-equiv="refresh" content="%d">', $this->nonce_timeout );
+		echo sprintf( '<meta http-equiv="refresh" content="%d">', esc_attr( $this->nonce_timeout ) );
 	}
 
+	/**
+	 * Add the nonce field to the form.
+	 */
 	public function add_nonce_to_form(): void {
 		wp_nonce_field( $this->nonce_action, $this->nonce_name );
 	}
 
+	/**
+	 * Initializes the nonce fields. Is only run on `login_init` to restrict nonce data to login page.
+	 */
 	public function initialize_nonce_fields(): void {
 		/**
 		 * Filters the nonce name.
 		 *
 		 * @param string $nonce_name The nonce name.
 		 */
-		$this->nonce_name    = (string) apply_filters( 'alleyvate_nonce_name', $this->generate_random_nonce_name('alleyvate_login_nonce') );
+		$this->nonce_name = (string) apply_filters( 'alleyvate_nonce_name', $this->generate_random_nonce_name( 'alleyvate_login_nonce' ) );
 
 		/**
 		 * Filters the nonce action name.
 		 *
 		 * @param string $nonce_action The action name.
 		 */
-		$this->nonce_action  = (string) apply_filters( 'alleyvate_nonce_action', 'alleyvate_login_action' );
+		$this->nonce_action = (string) apply_filters( 'alleyvate_nonce_action', 'alleyvate_login_action' );
 
 		/**
 		 * Filters the lifetime of the nonce, in minutes.
 		 *
 		 * @param int $timeout The lifetime of the nonce, in minutes. Default 30.
 		 */
-		$this->nonce_timeout = ((int) apply_filters( 'alleyvate_nonce_timeout', 30 )) * 60;
+		$this->nonce_timeout = ( (int) apply_filters( 'alleyvate_nonce_timeout', 30 ) ) * 60;
 
 		add_filter( 'nonce_life', fn() => $this->nonce_timeout );
 	}
@@ -91,11 +100,13 @@ final class Login_Nonce implements Feature {
 	 * Validates the passed nonce is valid. Returns a user object on valid login,
 	 * or void on invalid nonce.
 	 *
-	 * @param \WP_User|\WP_Error|null $user The result of previous login validations. An instance of
-	 *                    WP_User if all validations have passed previously.
+	 * @param \WP_User|\WP_Error|null $user     The result of previous login validations. An instance of
+	 *                                          WP_User if all validations have passed previously.
+	 * @param string                  $username The username used to try to login.
+	 * @param string                  $password The password used to try to login.
+	 * @return \WP_User|\WP_Error
 	 */
-	public function validate_login_nonce($user, $username, $password) {
-
+	public function validate_login_nonce( $user, $username, $password ) {
 		/*
 		 * If the filter is returning a \WP_Error, then validation has already failed.
 		 * No need to check the nonce.
@@ -114,8 +125,8 @@ final class Login_Nonce implements Feature {
 		 */
 		if ( null === $user ) {
 			// Remove this check to avoid infinite loops.
-			remove_filter( 'authenticate', [$this, 'validate_login_nonce'], 9999);
-			$user = apply_filters( 'authenticate', $user, $username, $password );
+			remove_filter( 'authenticate', [ $this, 'validate_login_nonce' ], 9999 );
+			$user = apply_filters( 'authenticate', $user, $username, $password ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		}
 
 		// We're sure about this value now. Exit early.
@@ -132,19 +143,33 @@ final class Login_Nonce implements Feature {
 
 		// If no post data exists, no nonce data exists, which means our login is invalid.
 		if ( empty( $_POST ) ) {
-			return;
+			return new \WP_Error(
+				'nonce_failure',
+				__( 'Login attempt timed out. Please try again.', 'alley' )
+			);
 		}
 
-		$nonce = $_POST[ $this->nonce_name ] ?? false;
+		$nonce = false;
+
+		if ( ! empty( $_POST[ $this->nonce_name ] ) ) {
+			$nonce = sanitize_key( $_POST[ $this->nonce_name ] );
+		}
 
 		if ( ! $nonce ) {
-			return null;
+			return new \WP_Error(
+				'nonce_failure',
+				__( 'Login attempt timed out. Please try again.', 'alley' )
+			);
+
 		}
 
-		$nonce_validation = wp_verify_nonce($nonce, $this->nonce_action);
+		$nonce_validation = wp_verify_nonce( $nonce, $this->nonce_action );
 
 		if ( ! $nonce_validation ) {
-			return null;
+			return new \WP_Error(
+				'nonce_failure',
+				__( 'Login attempt timed out. Please try again.', 'alley' )
+			);
 		}
 
 		return $user;
@@ -157,13 +182,13 @@ final class Login_Nonce implements Feature {
 	 * @return string
 	 */
 	private function generate_random_nonce_name( string $name ): string {
-		$parts = [$name];
-		if ( ! empty( $_SERVER ) ) {
-			foreach (['REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP'] as $key ) {
-				$value = ! empty( $_SERVER[ $key ] ) ? $_SERVER[ $key ] : '';
+		$parts = [ $name ];
+		if ( ! empty( $_SERVER ) ) { // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+			foreach ( [ 'REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP' ] as $key ) {
+				$value   = ! empty( $_SERVER[ $key ] ) ? sanitize_key( $_SERVER[ $key ] ) : '';
 				$parts[] = "{$key}={$value}";
 			}
 		}
-		return \hash('sha256', implode('-', $parts));
+		return \hash( 'sha256', implode( '-', $parts ) );
 	}
 }

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -33,6 +33,7 @@ function load(): void {
 		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
 		'disable_trackbacks'            => new Features\Disable_Trackbacks(),
 		'disallow_file_edit'            => new Features\Disallow_File_Edit(),
+		'login_none'                    => new Features\Login_Nonce(),
 		'redirect_guess_shortcircuit'   => new Features\Redirect_Guess_Shortcircuit(),
 		'user_enumeration_restrictions' => new Features\User_Enumeration_Restrictions(),
 	];

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -33,7 +33,7 @@ function load(): void {
 		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
 		'disable_trackbacks'            => new Features\Disable_Trackbacks(),
 		'disallow_file_edit'            => new Features\Disallow_File_Edit(),
-		'login_none'                    => new Features\Login_Nonce(),
+		'login_nonce'                   => new Features\Login_Nonce(),
 		'redirect_guess_shortcircuit'   => new Features\Redirect_Guess_Shortcircuit(),
 		'user_enumeration_restrictions' => new Features\User_Enumeration_Restrictions(),
 	];

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -48,10 +48,12 @@ final class Test_Login_Nonce extends Test_Case {
 
 		$this->feature->initialize_nonce_fields();
 
-		static::factory()->user->create([
-			'user_login' => 'nonce_user',
-			'user_pass' => 'password',
-		]);
+		static::factory()->user->create(
+			[
+				'user_login' => 'nonce_user',
+				'user_pass'  => 'password',
+			]
+		);
 
 		$_POST = [
 			'log' => 'nonce_user',
@@ -72,15 +74,17 @@ final class Test_Login_Nonce extends Test_Case {
 
 		$this->feature->initialize_nonce_fields();
 
-		static::factory()->user->create([
-			'user_login' => 'nonce_user',
-			'user_pass' => 'password',
-		]);
+		static::factory()->user->create(
+			[
+				'user_login' => 'nonce_user',
+				'user_pass'  => 'password',
+			]
+		);
 
 		$_POST = [
 			'log' => 'nonce_user',
 			'pwd' => 'password',
-			$this->feature->generate_random_nonce_name( 'alleyvate_login_nonce' ) => wp_create_nonce( 'alleyvate_login_action' )
+			$this->feature->generate_random_nonce_name( 'alleyvate_login_nonce' ) => wp_create_nonce( 'alleyvate_login_action' ),
 		];
 
 		add_filter( 'send_auth_cookies', '__return_false' );

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Class file for Test_Login_Nonce
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+use Mantle\Testing\Concerns\Refresh_Database;
+use Mantle\Testkit\Test_Case;
+use WP_Error;
+use WP_User;
+
+/**
+ * Tests for the login nonce.
+ */
+final class Test_Login_Nonce extends Test_Case {
+	use Refresh_Database;
+
+	/**
+	 * Feature instance.
+	 *
+	 * @var Login_Nonce
+	 */
+	private Login_Nonce $feature;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Login_Nonce();
+	}
+
+	/**
+	 * Test that login nonces are required to login successfully.
+	 */
+	public function test_logins_require_nonce() {
+		$this->feature->boot();
+
+		$this->feature->initialize_nonce_fields();
+
+		static::factory()->user->create([
+			'user_login' => 'nonce_user',
+			'user_pass' => 'password',
+		]);
+
+		$_POST = [
+			'log' => 'nonce_user',
+			'pwd' => 'password',
+		];
+
+		$user = wp_signon();
+
+		$this->assertInstanceOf( WP_Error::class, $user );
+		$this->assertSame( 'nonce_failure', $user->get_error_code() );
+	}
+
+	/**
+	 * Test that using nonces allow successful logins.
+	 */
+	public function test_logins_work_with_nonce() {
+		$this->feature->boot();
+
+		$this->feature->initialize_nonce_fields();
+
+		static::factory()->user->create([
+			'user_login' => 'nonce_user',
+			'user_pass' => 'password',
+		]);
+
+		$_POST = [
+			'log' => 'nonce_user',
+			'pwd' => 'password',
+			$this->feature->generate_random_nonce_name( 'alleyvate_login_nonce' ) => wp_create_nonce( 'alleyvate_login_action' )
+		];
+
+		add_filter( 'send_auth_cookies', '__return_false' );
+
+		$user = wp_signon();
+
+		$this->assertInstanceOf( WP_User::class, $user );
+	}
+}

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -46,6 +46,14 @@ final class Test_Login_Nonce extends Test_Case {
 	}
 
 	/**
+	 * Tear Down.
+	 */
+	protected function tearDown(): void {
+		$_POST = [];
+		parent::tearDown();
+	}
+
+	/**
 	 * Test that login nonces are required to login successfully.
 	 */
 	public function test_logins_require_nonce() {

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -8,6 +8,8 @@
  * file that was distributed with this source code.
  *
  * @package wp-alleyvate
+ *
+ * @phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.CodeAnalysis.EmptyStatement.DetectedCatch
  */
 
 namespace Alley\WP\Alleyvate\Features;
@@ -43,7 +45,7 @@ final class Test_Login_Nonce extends Test_Case {
 		/*
 		 * Prime the response code to 200 before running nonce validations.
 		 */
-		http_response_code(200);
+		http_response_code( 200 );
 	}
 
 	/**
@@ -62,7 +64,9 @@ final class Test_Login_Nonce extends Test_Case {
 
 		try {
 			Login_Nonce::action__pre_validate_login_nonce();
-		}catch( WP_Die_Exception $e ) {}
+		} catch ( WP_Die_Exception $e ) {
+			// Do nothing.
+		}
 
 		$this->assertSame( 403, http_response_code() );
 	}
@@ -82,7 +86,7 @@ final class Test_Login_Nonce extends Test_Case {
 		 */
 		add_filter( 'nonce_life', $nonce_life_filter );
 		$_POST = [
-			'wp-submit' => 'Log In',
+			'wp-submit'                               => 'Log In',
 			Login_Nonce::generate_random_nonce_name() => wp_create_nonce( Login_Nonce::NONCE_ACTION ),
 		];
 
@@ -92,7 +96,9 @@ final class Test_Login_Nonce extends Test_Case {
 
 		try {
 			Login_Nonce::action__pre_validate_login_nonce();
-		}catch( WP_Die_Exception $e ) {}
+		} catch ( WP_Die_Exception $e ) {
+			// Do nothing.
+		}
 
 		$this->assertSame( 200, http_response_code() );
 	}

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -50,6 +50,7 @@ final class Test_Login_Nonce extends Test_Case {
 	 */
 	protected function tearDown(): void {
 		$_POST = [];
+		http_response_code( 200 );
 		parent::tearDown();
 	}
 

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -63,7 +63,7 @@ final class Test_Login_Nonce extends Test_Case {
 		$this->feature->boot();
 
 		$_POST = [
-			'wp-submit' => 'Log In',
+			'pwd' => 'password',
 		];
 
 		$pagenow = 'wp-login.php';
@@ -82,6 +82,7 @@ final class Test_Login_Nonce extends Test_Case {
 	 */
 	public function test_logins_work_with_nonce() {
 		global $pagenow;
+
 		$this->feature->boot();
 
 		$nonce_life_filter = fn() => Login_Nonce::NONCE_TIMEOUT;
@@ -92,8 +93,8 @@ final class Test_Login_Nonce extends Test_Case {
 		 */
 		add_filter( 'nonce_life', $nonce_life_filter );
 		$_POST = [
-			'wp-submit'                               => 'Log In',
-			Login_Nonce::generate_random_nonce_name() => wp_create_nonce( Login_Nonce::NONCE_ACTION ),
+			'pwd'                   => 'password',
+			Login_Nonce::NONCE_NAME => wp_create_nonce( Login_Nonce::NONCE_ACTION ),
 		];
 
 		remove_filter( 'nonce_life', $nonce_life_filter );

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -14,12 +14,9 @@
 
 namespace Alley\WP\Alleyvate\Features;
 
-use Alley\WP\Alleyvate\Feature;
 use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Exceptions\WP_Die_Exception;
 use Mantle\Testkit\Test_Case;
-use WP_Error;
-use WP_User;
 
 /**
  * Tests for the login nonce.


### PR DESCRIPTION
## Summary

This PR adds a nonce to wp-login.php as described in [issue #49](https://github.com/alleyinteractive/wp-alleyvate/issues/49).

## Notes for reviewers

Please consider the potential overhead to the login process and the requirement for the page to be uncached when reviewing the changes.

## Changelog entries

### Added

- Added nonce to wp-login.php to prevent CSRF attacks and mitigate brute-force attacks, as described in [issue #49](https://github.com/alleyinteractive/wp-alleyvate/issues/49).

### Changed

### Deprecated

### Removed

### Fixed

### Security


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new security feature that adds nonce verification to the login process.

- **Bug Fixes**
  - Improved error handling and user validation during login.

- **Tests**
  - Added tests to ensure the login nonce feature works correctly and securely.

- **Refactor**
  - Adjusted the visibility of certain class constants for better encapsulation.

- **Documentation**
  - Updated documentation to reflect the addition of the login nonce feature and related methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->