### PR TITLE
Chore: Upgrading dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "composer/installers": "^1.0"
   },
   "require-dev": {
-    "alleyinteractive/alley-coding-standards": "^1.0",
+    "alleyinteractive/alley-coding-standards": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.8",
-    "mantle-framework/testkit": "^0.11"
+    "mantle-framework/testkit": "^0.12"
   },
   "scripts": {
     "fixer": "php-cs-fixer -v fix --allow-risky=yes",

--- a/src/alley/wp/alleyvate/features/class-disable-dashboard-widgets.php
+++ b/src/alley/wp/alleyvate/features/class-disable-dashboard-widgets.php
@@ -59,5 +59,4 @@ final class Disable_Dashboard_Widgets implements Feature {
 			remove_meta_box( $widget['id'], 'dashboard', $widget['context'] );
 		}
 	}
-
 }

--- a/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
+++ b/tests/alley/wp/alleyvate/features/test-clean-admin-bar.php
@@ -68,7 +68,6 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 		foreach ( $disposable_nodes as $disposable_node ) {
 			$this->assertArrayNotHasKey( $disposable_node, $current_nodes, $disposable_node . ' should not exist in $wp_admin_bar global after boot.' );
 		}
-
 	}
 
 	/**
@@ -102,7 +101,6 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 		$current_nodes = $admin_bar->get_nodes();
 
 		$this->assertArrayNotHasKey( $node, $current_nodes, 'The filtered node ' . $node . ' should not exist in $wp_admin_bar global after boot.' );
-
 	}
 
 	/**
@@ -122,5 +120,4 @@ final class Test_Clean_Admin_Bar extends Test_Case {
 
 		return $wp_admin_bar;
 	}
-
 }

--- a/tests/alley/wp/alleyvate/features/test-disable-comments.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-comments.php
@@ -19,8 +19,8 @@ use Mantle\Testkit\Test_Case;
  * Tests for fully disabling comment functionality.
  */
 final class Test_Disable_Comments extends Test_Case {
-	use \Mantle\Testing\Concerns\Admin_Screen,
-		\Mantle\Testing\Concerns\Refresh_Database;
+	use \Mantle\Testing\Concerns\Admin_Screen;
+	use \Mantle\Testing\Concerns\Refresh_Database;
 
 	/**
 	 * Feature instance.

--- a/tests/alley/wp/alleyvate/features/test-disable-dashboard-widgets.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-dashboard-widgets.php
@@ -36,6 +36,9 @@ final class Test_Disable_Dashboard_Widgets extends Test_Case {
 		parent::setUp();
 
 		$this->feature = new Disable_Dashboard_Widgets();
+
+		$this->prevent_stray_requests();
+		$this->fake_request();
 	}
 
 	/**

--- a/tests/alley/wp/alleyvate/features/test-disable-sticky-posts.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-sticky-posts.php
@@ -44,8 +44,8 @@ final class Test_Disable_Sticky_Posts extends Test_Case {
 	 */
 	public function test_disable_sticky_posts_in_query() {
 
-		$posts         = static::factory()->post->create_ordered_set( 5 );
-		$stick_post_id = static::factory()->post->create(
+		$posts         = self::factory()->post->create_ordered_set( 5 );
+		$stick_post_id = self::factory()->post->create(
 			[
 				'post_date' => '2019-01-01 00:00:00',
 			]
@@ -90,7 +90,7 @@ final class Test_Disable_Sticky_Posts extends Test_Case {
 	public function test_disable_action_sticky_rest_api_edit() {
 		$this->acting_as( 'administrator' );
 
-		$post_id = static::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		$this->get(
 			rest_url( 'wp/v2/posts/' . $post_id . '?context=edit' ),


### PR DESCRIPTION
- Upgrading Mantle TestKit to 0.12 and Alley Coding Standards (WPCS) to 2.0.
- Fixing coding standards to match Alley Coding Standards 2.0.
- Preventing an external HTTP request during testing.