### PR TITLE
Akismet: Removes the comment spam queue section from the WP dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.1
+
+### Added
+
+* Added a feature to add a nonce to wp-login
+
+### Changed
+
+* Akismet: Removed the comment spam queue section from the WP dashboard
+
 ## 2.2.0
 
 ### Added

--- a/src/alley/wp/alleyvate/features/class-disable-comments.php
+++ b/src/alley/wp/alleyvate/features/class-disable-comments.php
@@ -74,9 +74,11 @@ final class Disable_Comments implements Feature {
 	}
 
 	/**
-	 * Removes post type support for comments and filters REST responses for each post type to remove comment support.
+	 * Add actions and filters to run on the init hook.
 	 */
 	public static function action__init(): void {
+
+		// Removes post type support for comments and filters REST responses for each post type to remove comment support.
 		foreach ( get_post_types() as $post_type ) {
 			if ( post_type_supports( $post_type, 'comments' ) ) {
 				remove_post_type_support( $post_type, 'comments' );
@@ -85,6 +87,9 @@ final class Disable_Comments implements Feature {
 			// The REST API filters don't have a generic form, so they need to be registered for each post type.
 			add_filter( "rest_prepare_{$post_type}", [ self::class, 'filter__rest_prepare' ], 9999 );
 		}
+
+		// Removes the Akismet comments section from the dashboard.
+		remove_action( 'rightnow_end', [ 'Akismet_Admin', 'rightnow_stats' ] );
 	}
 
 	/**

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -14,7 +14,7 @@
  * Plugin Name: Alleyvate
  * Plugin URI: https://github.com/alleyinteractive/wp-alleyvate
  * Description: Defaults for WordPress sites by Alley
- * Version: 2.1.0
+ * Version: 2.2.1
  * Author: Alley
  * Author URI: https://www.alley.com
  * Requires at least: 6.2


### PR DESCRIPTION
## Summary

- As titled;
- `action__init` method phpDoc description updated to be more general;
- fixes #60 
- CHANGELOG updated with latest changes;
- Plugin version updated since it is outdated as per the [recent releases](https://github.com/alleyinteractive/wp-alleyvate/releases/tag/v2.2.0).

## Notes for reviewers

None.