### PR TITLE
Disable custom fields meta box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+* Added a feature to disable the custom fields meta box.
+
 ## 2.2.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 * Added a feature to disable the custom fields meta box.
 
+### Changed
+
+* Removes the `commentstatusdiv` meta box when comments are disabled.
+  Previously, only `commentsdiv` was removed.
+
 ## 2.2.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This feature removes selected nodes from the admin bar.
 
 This feature disables WordPress comments entirely, including the ability to post, view, edit, list, count, modify settings for, or access URLs that are related to comments completely.
 
+### `disable_custom_fields_meta_box`
+
+This feature removes the custom fields meta box from the post editor.
+
 ### `disable_dashboard_widgets`
 
 This feature removes clutter from the dashboard.

--- a/src/alley/wp/alleyvate/features/class-disable-comments.php
+++ b/src/alley/wp/alleyvate/features/class-disable-comments.php
@@ -42,6 +42,7 @@ final class Disable_Comments implements Feature {
 	 */
 	public static function action__add_meta_boxes( string $post_type ): void {
 		remove_meta_box( 'commentsdiv', $post_type, 'normal' );
+		remove_meta_box( 'commentstatusdiv', $post_type, 'normal' );
 	}
 
 	/**

--- a/src/alley/wp/alleyvate/features/class-disable-custom-fields-meta-box.php
+++ b/src/alley/wp/alleyvate/features/class-disable-custom-fields-meta-box.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Class file for Disable_Custom_Fields_Meta_Box
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+
+/**
+ * Disable the custom fields meta box.
+ */
+final class Disable_Custom_Fields_Meta_Box implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_action( 'add_meta_boxes', [ self::class, 'action__add_meta_boxes' ], 9999 );
+	}
+
+	/**
+	 * Remove the "Custom Fields" meta box.
+	 *
+	 * It generates an expensive query and is almost never used in practice.
+	 */
+	public static function action__add_meta_boxes(): void {
+		remove_meta_box( 'postcustom', null, 'normal' );
+	}
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -19,16 +19,17 @@ namespace Alley\WP\Alleyvate;
  */
 function available_features(): array {
 	return [
-		'clean_admin_bar'               => new Features\Clean_Admin_Bar(),
-		'disable_comments'              => new Features\Disable_Comments(),
-		'disable_dashboard_widgets'     => new Features\Disable_Dashboard_Widgets(),
-		'disable_sticky_posts'          => new Features\Disable_Sticky_Posts(),
-		'disable_trackbacks'            => new Features\Disable_Trackbacks(),
-		'disallow_file_edit'            => new Features\Disallow_File_Edit(),
-		'login_nonce'                   => new Features\Login_Nonce(),
-		'redirect_guess_shortcircuit'   => new Features\Redirect_Guess_Shortcircuit(),
-		'site_health'                   => new Features\Site_Health(),
-		'user_enumeration_restrictions' => new Features\User_Enumeration_Restrictions(),
+		'clean_admin_bar'                => new Features\Clean_Admin_Bar(),
+		'disable_comments'               => new Features\Disable_Comments(),
+		'disable_dashboard_widgets'      => new Features\Disable_Dashboard_Widgets(),
+		'disable_custom_fields_meta_box' => new Features\Disable_Custom_Fields_Meta_Box(),
+		'disable_sticky_posts'           => new Features\Disable_Sticky_Posts(),
+		'disable_trackbacks'             => new Features\Disable_Trackbacks(),
+		'disallow_file_edit'             => new Features\Disallow_File_Edit(),
+		'login_nonce'                    => new Features\Login_Nonce(),
+		'redirect_guess_shortcircuit'    => new Features\Redirect_Guess_Shortcircuit(),
+		'site_health'                    => new Features\Site_Health(),
+		'user_enumeration_restrictions'  => new Features\User_Enumeration_Restrictions(),
 	];
 }
 

--- a/tests/alley/wp/alleyvate/features/concerns/trait-remove-meta-box.php
+++ b/tests/alley/wp/alleyvate/features/concerns/trait-remove-meta-box.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class file for Test_Disable_Custom_Fields_Meta_Box
+ * Trait file for Remove_Meta_Box
  *
  * (c) Alley <info@alley.com>
  *
@@ -41,7 +41,7 @@ trait Remove_Meta_Box {
 		require_once ABSPATH . 'wp-admin/includes/theme.php';
 		require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
 
-		// Setup metaboxes global and confirm 'custom fields' are in it.
+		// Setup metaboxes global and confirm that the metabox is registered.
 		set_current_screen( $screen );
 		register_and_do_post_meta_boxes( $post );
 

--- a/tests/alley/wp/alleyvate/features/concerns/trait-remove-meta-box.php
+++ b/tests/alley/wp/alleyvate/features/concerns/trait-remove-meta-box.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Class file for Test_Disable_Custom_Fields_Meta_Box
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features\Concerns;
+
+use Alley\WP\Alleyvate\Feature;
+
+/**
+ * Test the removal of a meta box.
+ */
+trait Remove_Meta_Box {
+	use \Mantle\Testing\Concerns\Admin_Screen;
+
+	/**
+	 * Test the removal of a meta box.
+	 *
+	 * @param Feature $feature  Feature instance.
+	 * @param string  $id       Meta box ID.
+	 * @param string  $screen   Screen to test on.
+	 * @param string  $context  Meta box context.
+	 * @param string  $priority Meta box priority.
+	 * @return void
+	 */
+	protected function assertMetaBoxRemoval( Feature $feature, string $id, string $screen = 'post', string $context = 'normal', string $priority = 'default' ): void {
+		$post = self::factory()->post->create_and_get();
+
+		// Load files required to get $wp_meta_boxes global.
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+		require_once ABSPATH . 'wp-admin/includes/theme.php';
+		require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
+
+		// Setup metaboxes global and confirm 'custom fields' are in it.
+		set_current_screen( $screen );
+		register_and_do_post_meta_boxes( $post );
+
+		global $wp_meta_boxes;
+		$this->assertNotEmpty(
+			$wp_meta_boxes[ $screen ][ $context ][ $priority ][ $id ] ?? null,
+			"Meta box {$id} was not registered."
+		);
+
+		// Activate feature.
+		$feature->boot();
+
+		register_and_do_post_meta_boxes( $post );
+
+		// Confirm that the metabox is removed.
+		$this->assertFalse(
+			$wp_meta_boxes[ $screen ][ $context ][ $priority ][ $id ],
+			"Meta box {$id} was not removed."
+		);
+	}
+}

--- a/tests/alley/wp/alleyvate/features/test-disable-comments.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-comments.php
@@ -19,6 +19,7 @@ use Mantle\Testkit\Test_Case;
  * Tests for fully disabling comment functionality.
  */
 final class Test_Disable_Comments extends Test_Case {
+	use Concerns\Remove_Meta_Box;
 	use \Mantle\Testing\Concerns\Admin_Screen;
 	use \Mantle\Testing\Concerns\Refresh_Database;
 
@@ -163,29 +164,14 @@ final class Test_Disable_Comments extends Test_Case {
 	}
 
 	/**
-	 * Test that the comments metaboxes are removed.
+	 * Test that the comments meta boxes are removed.
 	 */
-	public function test_remove_metaboxes(): void {
-		$post = self::factory()->post->create_and_get();
-
-		// Load files required to get $wp_meta_boxes global.
-		require_once ABSPATH . 'wp-admin/includes/misc.php';
-		require_once ABSPATH . 'wp-admin/includes/template.php';
-		require_once ABSPATH . 'wp-admin/includes/theme.php';
-		require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
-
-		// Setup metaboxes global and confirm comments are in it.
-		set_current_screen( 'post' );
-		register_and_do_post_meta_boxes( $post );
-		global $wp_meta_boxes;
-		$this->assertNotEmpty( $wp_meta_boxes['post']['normal']['core']['commentsdiv'] );
-
-		// Activate feature.
-		$this->feature->boot();
-
-		// Confirm metaboxes are removed.
-		register_and_do_post_meta_boxes( $post );
-		$this->assertFalse( $wp_meta_boxes['post']['normal']['core']['commentsdiv'] );
+	public function test_remove_meta_boxes(): void {
+		$this->assertMetaBoxRemoval(
+			feature: $this->feature,
+			id: 'commentsdiv',
+			priority: 'core',
+		);
 	}
 
 	/**

--- a/tests/alley/wp/alleyvate/features/test-disable-custom-fields-meta-box.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-custom-fields-meta-box.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Class file for Test_Disable_Custom_Fields_Meta_Box
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Alleyvate\Feature;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for the disabling of the custom fields meta box.
+ */
+final class Test_Disable_Custom_Fields_Meta_Box extends Test_Case {
+	use Concerns\Remove_Meta_Box;
+
+	/**
+	 * Feature instance.
+	 *
+	 * @var Feature
+	 */
+	private Feature $feature;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Disable_Custom_Fields_Meta_Box();
+	}
+
+	/**
+	 * Test that the custom fields metaboxes is removed.
+	 */
+	public function test_remove_metaboxes(): void {
+		$this->assertMetaBoxRemoval(
+			feature: $this->feature,
+			id: 'postcustom',
+			priority: 'core',
+		);
+	}
+}


### PR DESCRIPTION
- Removes the 'Custom Fields' meta box. 
- Removes the `commentstatusdiv` meta box when comments are disabled.

Resolves #23.