### PR TITLE
Login Nonce: nonce lifetime is changed only for the login action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Changed
 
 * `login_nonce`: make sure the nonce lifetime is run only for the login action
-  as to not affect the other `wp-login.php`` actions, e.g: logout.
+  as to not affect the other `wp-login.php` actions, e.g: logout.
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 2.3.1
+
+### Changed
+
+* `login_nonce`: make sure the nonce lifetime is run only for the login action
+  as to not affect the other `wp-login.php`` actions, e.g: logout.
+
 ## 2.3.0
 
 ### Added
@@ -19,11 +26,11 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-* Added a feature to add a nonce to wp-login
+* `login_nonce`: Added a feature to add a nonce to wp-login
 
 ### Changed
 
-* Akismet: Removed the comment spam queue section from the WP dashboard
+* `disable_comments`: Akismet: Removed the comment spam queue section from the WP dashboard
 
 ## 2.2.0
 

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -63,8 +63,6 @@ final class Login_Nonce implements Feature {
 	/**
 	 * Add the nonce field to the form.
 	 *
-	 * This adds the nonce to all form actions, but we verify the nonce only while logging in.
-	 *
 	 * @see action__add_nonce_life_filter()
 	 */
 	public static function action__add_nonce_to_form(): void {

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -64,7 +64,7 @@ final class Login_Nonce implements Feature {
 	/**
 	 * Add the nonce field to the form.
 	 *
-	 * This adds the nonce to all form actions, but we verify the nonce only while loging in.
+	 * This adds the nonce to all form actions, but we verify the nonce only while logging in.
 	 *
 	 * @see action__add_nonce_life_filter()
 	 */
@@ -76,7 +76,7 @@ final class Login_Nonce implements Feature {
 	 * Add a filter to change the nonce lifetime.
 	 *
 	 * Changing the lifetime of the nonce changes the actual nonce value. It all comes down to how WordPress actually generates the nonce.
-	 * So only run on `login_form_login` to restrict to the login page, without affecting other login actions.
+	 * So only run on `login_form_login` to restrict to the login action, without affecting other wp-login actions.
 	 *
 	 * @see <https://github.com/WordPress/wordpress-develop/blob/94b70f1ae065f10937c22b2d4b180ceade1ddeee/src/wp-login.php#L482-L495>
 	 */

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -48,9 +48,9 @@ final class Login_Nonce implements Feature {
 	 * Boot the feature.
 	 */
 	public function boot(): void {
-		add_action( 'login_init', [ self::class, 'action__add_nonce_life_filter' ] );
-		add_action( 'login_head', [ self::class, 'action__add_meta_refresh' ] );
+		add_action( 'login_form_login', [ self::class, 'action__add_nonce_life_filter' ] );
 		add_action( 'login_form', [ self::class, 'action__add_nonce_to_form' ] );
+		add_action( 'login_head', [ self::class, 'action__add_meta_refresh' ] );
 		add_action( 'after_setup_theme', [ self::class, 'action__pre_validate_login_nonce' ], 9999 );
 	}
 
@@ -63,13 +63,22 @@ final class Login_Nonce implements Feature {
 
 	/**
 	 * Add the nonce field to the form.
+	 *
+	 * This adds the nonce to all form actions, but we verify the nonce only while loging in.
+	 *
+	 * @see action__add_nonce_life_filter()
 	 */
 	public static function action__add_nonce_to_form(): void {
 		wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME );
 	}
 
 	/**
-	 * Initializes the nonce fields. Is only run on `login_init` to restrict nonce data to login page.
+	 * Add a filter to change the nonce lifetime.
+	 *
+	 * Changing the lifetime of the nonce changes the actual nonce value. It all comes down to how WordPress actually generates the nonce.
+	 * So only run on `login_form_login` to restrict to the login page, without affecting other login actions.
+	 *
+	 * @see <https://github.com/WordPress/wordpress-develop/blob/94b70f1ae065f10937c22b2d4b180ceade1ddeee/src/wp-login.php#L482-L495>
 	 */
 	public static function action__add_nonce_life_filter(): void {
 		add_filter( 'nonce_life', [ __CLASS__, 'nonce_life_filter' ] );

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -49,7 +49,6 @@ final class Login_Nonce implements Feature {
 	 */
 	public function boot(): void {
 		add_action( 'login_form_login', [ self::class, 'action__add_nonce_life_filter' ] );
-		add_action( 'login_form', [ self::class, 'action__add_nonce_to_form' ] );
 		add_action( 'login_head', [ self::class, 'action__add_meta_refresh' ] );
 		add_action( 'after_setup_theme', [ self::class, 'action__pre_validate_login_nonce' ], 9999 );
 	}
@@ -82,6 +81,7 @@ final class Login_Nonce implements Feature {
 	 */
 	public static function action__add_nonce_life_filter(): void {
 		add_filter( 'nonce_life', [ __CLASS__, 'nonce_life_filter' ] );
+		add_action( 'login_form', [ __CLASS__, 'action__add_nonce_to_form' ] );
 	}
 
 	/**

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -9,7 +9,7 @@
  *
  * @package wp-alleyvate
  *
- * @phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+ * @phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.CodeAnalysis.EmptyStatement.DetectedCatch, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
  */
 
 namespace Alley\WP\Alleyvate\Features;
@@ -140,7 +140,7 @@ final class Test_Login_Nonce extends Test_Case {
 
 		$token = wp_create_nonce( 'log-out' );
 
-		do_action( 'login_init' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		do_action( 'login_init' );
 
 		$this->assertTrue( wp_validate_boolean( wp_verify_nonce( $token, 'log-out' ) ) );
 	}

--- a/tests/alley/wp/alleyvate/features/test-login-nonce.php
+++ b/tests/alley/wp/alleyvate/features/test-login-nonce.php
@@ -52,8 +52,6 @@ final class Test_Login_Nonce extends Test_Case {
 
 		$this->feature = new Login_Nonce();
 
-		$this->feature->boot();
-
 		/*
 		 * Prime the response code to 200 before running nonce validations.
 		 */
@@ -66,6 +64,9 @@ final class Test_Login_Nonce extends Test_Case {
 	protected function tearDown(): void {
 		$_POST = [];
 		http_response_code( 200 );
+
+		remove_action( 'nonce_life', [ Login_Nonce::class, 'nonce_life_filter' ] );
+
 		parent::tearDown();
 	}
 
@@ -124,6 +125,8 @@ final class Test_Login_Nonce extends Test_Case {
 	 * Test the login nonce doesn't affect other wp-login.php actions.
 	 */
 	public function test_login_nonce_validates(): void {
+		$this->feature->boot();
+
 		$token = wp_create_nonce( Login_Nonce::NONCE_ACTION );
 
 		$this->assertTrue( wp_validate_boolean( wp_verify_nonce( $token, Login_Nonce::NONCE_ACTION ) ) );
@@ -133,6 +136,8 @@ final class Test_Login_Nonce extends Test_Case {
 	 * Test the login nonce doesn't affect other wp-login.php actions.
 	 */
 	public function test_logout_nonce_validates(): void {
+		$this->feature->boot();
+
 		$token = wp_create_nonce( 'log-out' );
 
 		do_action( 'login_init' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -14,7 +14,7 @@
  * Plugin Name: Alleyvate
  * Plugin URI: https://github.com/alleyinteractive/wp-alleyvate
  * Description: Defaults for WordPress sites by Alley
- * Version: 2.3.0
+ * Version: 2.3.1
  * Author: Alley
  * Author URI: https://www.alley.com
  * Requires at least: 6.2


### PR DESCRIPTION
## Summary

Make sure the nonce lifetime is run only for the login action as to not affect the other `wp-login.php` actions, e.g: logout.

Currently, when trying to log out, the `log-out` nonce mismatch (since it is changed) and a user sees the following screen:

<img width="1698" alt="Screenshot 2024-01-11 at 10 38 18 AM" src="https://github.com/alleyinteractive/wp-alleyvate/assets/19148962/99307eac-fb7c-4963-86f8-d7fffeab5261">

## Notes for reviewers

None.
