### PR TITLE
Remove shortlink from the head of the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Added
 
 * `Alley\WP\Alleyvate\Feature` class implementing the `Alley\WP\Types\Feature` interface.
+* `remove_shortlink`: Added a feature to remove the shortlink from the head of the site.
 
 ### Changed
 
@@ -22,7 +23,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Removed
 
 * `site_health`: Removed as a dedicated feature and now implemented directly in the plugin.
-* `Alley\WP\Alleyvate\Feature` interface. 
+* `Alley\WP\Alleyvate\Feature` interface.
 
 ## 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ This feature stops WordPress from attempting to guess a redirect URL for a 404 r
 
 The underlying behavior of `redirect_guess_404_permalink()` often confuses clients, and its database queries are non-performant on larger sites.
 
+### `remove_shortlink`
+
+This feature removes the shortlink from the head of the site. By default,
+WordPress adds a shortlink to the head of the site, which is not used by most
+sites.
+
 ### `user_enumeration_restrictions`
 
 This feature requires users to be logged in before accessing data about registered users that would otherwise be publicly accessible. Its handle is `user_enumeration_restrictions`.

--- a/src/alley/wp/alleyvate/features/class-remove-shortlink.php
+++ b/src/alley/wp/alleyvate/features/class-remove-shortlink.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class file for Remove_Shortlink
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Remove the shortlink link tag from the head of pages.
+ */
+final class Remove_Shortlink implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		remove_action( 'wp_head', 'wp_shortlink_wp_head', 10 );
+	}
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -77,6 +77,10 @@ function load(): void {
 			'user_enumeration_restrictions',
 			new Features\User_Enumeration_Restrictions(),
 		),
+		new Feature(
+			'remove_shortlink',
+			new Features\Remove_Shortlink(),
+		),
 	);
 
 	$plugin->boot();

--- a/tests/alley/wp/alleyvate/features/test-remove-shortlink.php
+++ b/tests/alley/wp/alleyvate/features/test-remove-shortlink.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Class file for Test_Remove_Shortlink
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+declare( strict_types=1 );
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Mantle\Testing\Concerns\Refresh_Database;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for removing the shortlink link tag from the head of pages.
+ */
+final class Test_Remove_Shortlink extends Test_Case {
+	use Refresh_Database;
+
+	/**
+	 * Feature instance.
+	 *
+	 * @var Remove_Shortlink
+	 */
+	private Remove_Shortlink $feature;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Remove_Shortlink();
+	}
+
+	/**
+	 * Test that the feature removes the shortlink link tag from the head of pages.
+	 */
+	public function test_boot(): void {
+		$post = self::factory()->post->create_and_get();
+
+		$this->get( $post )->assertElementExists( 'head/link[@rel="shortlink"]' );
+
+		$this->feature->boot();
+
+		$this->get( $post )->assertElementMissing( 'head/link[@rel="shortlink"]' );
+	}
+}


### PR DESCRIPTION
Adds a new feature to remove the shortlink tag from the head of the page.

Resolves #38