### PR TITLE
Cache Months Dropdown in Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 * Added PHPStan to the development dependencies.
 * `Alley\WP\Alleyvate\Feature` class implementing the `Alley\WP\Types\Feature` interface.
 * `remove_shortlink`: Added a feature to remove the shortlink from the head of the site.
+* `cache_slow_queries`: Added a feature to cache slow queries for performance.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ add_filter( 'alleyvate_load_disable_comments', '__return_false' );
 
 Each feature's handle is listed below, along with a description of what it does.
 
+### `cache_slow_queries`
+
+This feature caches/optimizes slow queries to the database to improve
+performance. It is enabled by default and currently includes the following slow
+queries:
+
+- `months_dropdown`: The dropdown for selecting a month in the post list table.
+
 ### `clean_admin_bar`
 
 This feature removes selected nodes from the admin bar.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Each feature's handle is listed below, along with a description of what it does.
 
 This feature caches/optimizes slow queries to the database to improve
 performance. It is enabled by default and currently includes the following slow
-queries:
+queries with the relevant filters to disable them:
 
-- `months_dropdown`: The dropdown for selecting a month in the post list table.
+- `alleyvate_cache_months_dropdown`: The dropdown for selecting a month in the post list table.
 
 ### `clean_admin_bar`
 

--- a/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
+++ b/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
@@ -38,7 +38,7 @@ final class Cache_Slow_Queries implements Feature {
 	public function filter__pre_months_dropdown_query( $months, $post_type ) {
 		$cache = wp_cache_get( $post_type, 'alleyvate_months_dropdown' );
 
-		return false !== $cache && is_object( $cache ) ? $cache : $months;
+		return false !== $cache && \is_object( $cache ) ? $cache : $months;
 	}
 
 	/**

--- a/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
+++ b/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
@@ -31,22 +31,22 @@ final class Cache_Slow_Queries implements Feature {
 	/**
 	 * Filter the pre months dropdown query to return the cached result.
 	 *
-	 * @param object[]|false $months 'Months' drop-down results. Default false.
-	 * @param string         $post_type The post type.
-	 * @return object[]|false
+	 * @param object|false $months 'Months' drop-down results. Default false.
+	 * @param string       $post_type The post type.
+	 * @return object|false
 	 */
 	public function filter__pre_months_dropdown_query( $months, $post_type ) {
 		$cache = wp_cache_get( $post_type, 'alleyvate_months_dropdown' );
 
-		return $cache ?: $months;
+		return false !== $cache && is_object( $cache ) ? $cache : $months;
 	}
 
 	/**
 	 * Filter the months dropdown results.
 	 *
-	 * @param object[] $months    Array of the months drop-down query results.
-	 * @param string   $post_type The post type.
-	 * @return object[]|false
+	 * @param object $months    Array of the months drop-down query results.
+	 * @param string $post_type The post type.
+	 * @return object|false
 	 */
 	public function filter__months_dropdown_results( $months, $post_type ) {
 		wp_cache_set( $post_type, $months, 'alleyvate_months_dropdown' );

--- a/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
+++ b/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
@@ -19,38 +19,91 @@ use Alley\WP\Types\Feature;
  */
 final class Cache_Slow_Queries implements Feature {
 	/**
+	 * Whether to cache the months dropdown.
+	 *
+	 * @var bool
+	 */
+	public bool $cache_months_dropdown = false;
+
+	/**
 	 * Boot the feature.
 	 */
 	public function boot(): void {
+		/**
+		 * Filter if the months dropdown query should be cached.
+		 *
+		 * @param bool $cache_months_dropdown Whether to cache the months dropdown. Default true.
+		 */
 		if ( apply_filters( 'alleyvate_cache_months_dropdown', true ) ) {
 			add_filter( 'pre_months_dropdown_query', [ $this, 'filter__pre_months_dropdown_query' ], 10, 2 );
 			add_filter( 'months_dropdown_results', [ $this, 'filter__months_dropdown_results' ], 10, 2 );
+			add_action( 'save_post', [ $this, 'action__save_post' ], 10, 2 );
 		}
 	}
 
 	/**
 	 * Filter the pre months dropdown query to return the cached result.
 	 *
-	 * @param object|false $months 'Months' drop-down results. Default false.
-	 * @param string       $post_type The post type.
-	 * @return object|false
+	 * @param object[]|false $months 'Months' drop-down results. Default false.
+	 * @param string         $post_type The post type.
+	 * @return object[]|false
 	 */
 	public function filter__pre_months_dropdown_query( $months, $post_type ) {
 		$cache = wp_cache_get( $post_type, 'alleyvate_months_dropdown' );
 
-		return false !== $cache && \is_object( $cache ) ? $cache : $months;
+		if ( is_array( $cache ) ) {
+			return $cache;
+		}
+
+		// Set the flag to cache the months dropdown.
+		$this->cache_months_dropdown = true;
+
+		return $months;
 	}
 
 	/**
 	 * Filter the months dropdown results.
 	 *
-	 * @param object $months    Array of the months drop-down query results.
-	 * @param string $post_type The post type.
-	 * @return object|false
+	 * @param object[] $months    Array of the months drop-down query results.
+	 * @param string   $post_type The post type.
+	 * @return object[]|false
 	 */
 	public function filter__months_dropdown_results( $months, $post_type ) {
-		wp_cache_set( $post_type, $months, 'alleyvate_months_dropdown', DAY_IN_SECONDS );
+		if ( $this->cache_months_dropdown ) {
+			wp_cache_set( $post_type, $months, 'alleyvate_months_dropdown', DAY_IN_SECONDS );
+
+			$this->cache_months_dropdown = false;
+		}
 
 		return $months;
+	}
+
+	/**
+	 * Action to delete the cache when a post is published.
+	 *
+	 * @param int      $post_id The post ID.
+	 * @param \WP_Post $post    The post object.
+	 */
+	public function action__save_post( $post_id, $post ): void {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		$cache = wp_cache_get( $post->post_type, 'alleyvate_months_dropdown' );
+
+		if ( ! is_array( $cache ) ) {
+			return;
+		}
+
+		// Check if the post's month is in the cache.
+		$cache = array_map(
+			fn ( $month ) => "{$month->year}-{$month->month}",
+			$cache,
+		);
+
+		// Clear the month dropdown cache if the post's month is not in the cache.
+		if ( ! in_array( get_the_date( 'Y-n', $post ), $cache, true ) ) {
+			wp_cache_delete( $post->post_type, 'alleyvate_months_dropdown' );
+		}
 	}
 }

--- a/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
+++ b/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
@@ -49,7 +49,7 @@ final class Cache_Slow_Queries implements Feature {
 	 * @return object|false
 	 */
 	public function filter__months_dropdown_results( $months, $post_type ) {
-		wp_cache_set( $post_type, $months, 'alleyvate_months_dropdown' );
+		wp_cache_set( $post_type, $months, 'alleyvate_months_dropdown', DAY_IN_SECONDS );
 
 		return $months;
 	}

--- a/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
+++ b/src/alley/wp/alleyvate/features/class-cache-slow-queries.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Cache_Slow_Queries class file
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Cache slow queries that do not perform well for large sites.
+ */
+final class Cache_Slow_Queries implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		if ( apply_filters( 'alleyvate_cache_months_dropdown', true ) ) {
+			add_filter( 'pre_months_dropdown_query', [ $this, 'filter__pre_months_dropdown_query' ], 10, 2 );
+			add_filter( 'months_dropdown_results', [ $this, 'filter__months_dropdown_results' ], 10, 2 );
+		}
+	}
+
+	/**
+	 * Filter the pre months dropdown query to return the cached result.
+	 *
+	 * @param object[]|false $months 'Months' drop-down results. Default false.
+	 * @param string         $post_type The post type.
+	 * @return object[]|false
+	 */
+	public function filter__pre_months_dropdown_query( $months, $post_type ) {
+		$cache = wp_cache_get( $post_type, 'alleyvate_months_dropdown' );
+
+		return $cache ?: $months;
+	}
+
+	/**
+	 * Filter the months dropdown results.
+	 *
+	 * @param object[] $months    Array of the months drop-down query results.
+	 * @param string   $post_type The post type.
+	 * @return object[]|false
+	 */
+	public function filter__months_dropdown_results( $months, $post_type ) {
+		wp_cache_set( $post_type, $months, 'alleyvate_months_dropdown' );
+
+		return $months;
+	}
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -26,6 +26,10 @@ function load(): void {
 	$plugin = new Group(
 		new Site_Health_Panel(),
 		new Feature(
+			'cache_slow_queries',
+			new Features\Cache_Slow_Queries(),
+		),
+		new Feature(
 			'clean_admin_bar',
 			new Features\Clean_Admin_Bar(),
 		),

--- a/tests/alley/wp/alleyvate/features/test-cache-slow-queries.php
+++ b/tests/alley/wp/alleyvate/features/test-cache-slow-queries.php
@@ -94,7 +94,7 @@ final class Test_Cache_Slow_Queries extends Test_Case {
 	/**
 	 * Test that the cache is cleared for the months dropdown query when the post is published.
 	 */
-	public function test_optimize_months_dropdown_cache_cleared_on_publish() {
+	public function test_optimize_months_dropdown_cache_cleared_on_publish(): void {
 		self::factory()->post->create( [ 'post_date' => '2020-01-05 00:00:00' ] );
 
 		// Prime the cache with some old months.

--- a/tests/alley/wp/alleyvate/features/test-cache-slow-queries.php
+++ b/tests/alley/wp/alleyvate/features/test-cache-slow-queries.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Class file for Test_Cache_Slow_Queries
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+declare( strict_types=1 );
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Mantle\Testing\Concerns\Admin_Screen;
+use Mantle\Testkit\Test_Case;
+use Mantle\Testing\Concerns\Refresh_Database;
+
+/**
+ * Tests for caching slow queries.
+ */
+final class Test_Cache_Slow_Queries extends Test_Case {
+	use Admin_Screen;
+	use Refresh_Database;
+
+	/**
+	 * Feature instance.
+	 *
+	 * @var Cache_Slow_Queries
+	 */
+	private Cache_Slow_Queries $feature;
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @param array ...$args The array of arguments passed to the class.
+	 */
+	public function __construct( ...$args ) {
+		parent::__construct( ...$args );
+
+		// Run the test in isolation to prevent conflicts with other admin tests.
+		$this->setPreserveGlobalState( false );
+		$this->setRunClassInSeparateProcess( true );
+	}
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Cache_Slow_Queries();
+	}
+
+	/**
+	 * Test optimizing the date query for the months dropdown.
+	 */
+	public function test_optimize_months_dropdown(): void {
+		$this->expectApplied( 'pre_months_dropdown_query' )->once();
+		$this->expectApplied( 'months_dropdown_results' )->once();
+
+		self::factory()->post->create_many( 10 );
+
+		set_current_screen( 'edit-post' );
+
+		$this->acting_as( 'administrator' );
+
+		// Boot feature.
+		$this->feature->boot();
+
+		// Require the WP_List_Table class and boot it.
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-posts-list-table.php';
+
+		ob_start();
+
+		// Get the months dropdown.
+		$table = new \WP_Posts_List_Table(
+			[
+				'screen' => get_current_screen(),
+			],
+		);
+
+		$table->display();
+
+		ob_end_clean();
+
+		$this->assertNotEmpty( wp_cache_get( 'post', 'alleyvate_months_dropdown' ) );
+	}
+}

--- a/tests/alley/wp/alleyvate/features/test-cache-slow-queries.php
+++ b/tests/alley/wp/alleyvate/features/test-cache-slow-queries.php
@@ -90,4 +90,31 @@ final class Test_Cache_Slow_Queries extends Test_Case {
 
 		$this->assertNotEmpty( wp_cache_get( 'post', 'alleyvate_months_dropdown' ) );
 	}
+
+	/**
+	 * Test that the cache is cleared for the months dropdown query when the post is published.
+	 */
+	public function test_optimize_months_dropdown_cache_cleared_on_publish() {
+		self::factory()->post->create( [ 'post_date' => '2020-01-05 00:00:00' ] );
+
+		// Prime the cache with some old months.
+		wp_cache_set(
+			'post',
+			[
+				(object) [
+					'year'  => 2020,
+					'month' => 1,
+				],
+			],
+			'alleyvate_months_dropdown'
+		);
+
+		// Boot feature.
+		$this->feature->boot();
+
+		// Publish a post which should clear the cache.
+		self::factory()->post->create( [ 'post_date' => '2022-02-05 00:00:00' ] );
+
+		$this->assertEmpty( wp_cache_get( 'post', 'alleyvate_months_dropdown' ) );
+	}
 }

--- a/tests/alley/wp/alleyvate/features/test-disable-comments.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-comments.php
@@ -155,6 +155,7 @@ final class Test_Disable_Comments extends Test_Case {
 		// Build the admin bar menu and ensure comments are in it by default.
 		$this->get( admin_url() );
 		global $wp_admin_bar;
+		set_current_screen( 'dashboard' );
 		do_action( 'admin_bar_menu', $wp_admin_bar ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$this->assertNotEmpty( $wp_admin_bar->get_node( 'comments' ) );
 


### PR DESCRIPTION
Add a feature to cache the slow months query dropdown in the admin.

![CleanShot 2024-03-06 at 15 09 34@2x](https://github.com/alleyinteractive/wp-alleyvate/assets/346399/cff46e97-869a-405d-bf81-731b3c343ae2)
