### PR TITLE
Issue-85: Pantheon site protocol scheme should match the db value regardless of request type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+* `disable_pantheon_constant_overrides`: Added a feature to disable forcing use of `WP_SITEURL` and `WP_HOME` on Pantheon environments.
+
 ## 3.0.1
 
 - Removing `composer/installers` from Composer dependencies.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ This feature prevents the editing of themes and plugins directly from the admin.
 
 Such editing can introduce unexpected and undocumented code changes.
 
+### `disable_pantheon_constant_overrides`
+
+This feature prevents Pantheon environments from forcing CLI and Cron runs to use the `WP_HOME` or `WP_SITEURL` constants,
+which have been shown to force those environments to use an insecure protocol at times.
+
 ### `login_nonce`
 
 This feature adds a nonce to the login form to prevent CSRF attacks.

--- a/src/alley/wp/alleyvate/features/class-disable-pantheon-constant-overrides.php
+++ b/src/alley/wp/alleyvate/features/class-disable-pantheon-constant-overrides.php
@@ -27,8 +27,8 @@ final class Disable_Pantheon_Constant_Overrides implements Feature {
 		if (
 			isset( $_ENV['PANTHEON_ENVIRONMENT'] ) &&
 			(
-				( defined( 'WP_CLI' ) && WP_CLI ) ||
-				( defined( 'DOING_CRON' ) && DOING_CRON )
+				( \defined( 'WP_CLI' ) && WP_CLI ) ||
+				( \defined( 'DOING_CRON' ) && DOING_CRON )
 			)
 		) {
 			remove_filter( 'option_siteurl', '_config_wp_siteurl' );

--- a/src/alley/wp/alleyvate/features/class-disable-pantheon-constant-overrides.php
+++ b/src/alley/wp/alleyvate/features/class-disable-pantheon-constant-overrides.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Class file for Disable_Pantheon_Constant_Overrides
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Disallow the WP_SITEURL and WP_HOME constants from overriding the option
+ * value on Cron or CLI runs.
+ */
+final class Disable_Pantheon_Constant_Overrides implements Feature {
+
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		if (
+			isset( $_ENV['PANTHEON_ENVIRONMENT'] ) &&
+			(
+				( defined( 'WP_CLI' ) && WP_CLI ) ||
+				( defined( 'DOING_CRON' ) && DOING_CRON )
+			)
+		) {
+			remove_filter( 'option_siteurl', '_config_wp_siteurl' );
+			remove_filter( 'option_home', '_config_wp_home' );
+		}
+	}
+
+}

--- a/src/alley/wp/alleyvate/features/class-disable-pantheon-constant-overrides.php
+++ b/src/alley/wp/alleyvate/features/class-disable-pantheon-constant-overrides.php
@@ -35,5 +35,4 @@ final class Disable_Pantheon_Constant_Overrides implements Feature {
 			remove_filter( 'option_home', '_config_wp_home' );
 		}
 	}
-
 }

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -86,7 +86,7 @@ function load(): void {
 			new Features\Remove_Shortlink(),
 		),
 		new Feature(
-			'pantheon_constant_overrides',
+			'disable_pantheon_constant_overrides',
 			new Features\Disable_Pantheon_Constant_Overrides(),
 		)
 	);

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -85,6 +85,10 @@ function load(): void {
 			'remove_shortlink',
 			new Features\Remove_Shortlink(),
 		),
+		new Feature(
+			'pantheon_constant_overrides',
+			new Features\Disable_Pantheon_Constant_Overrides(),
+		)
 	);
 
 	$plugin->boot();


### PR DESCRIPTION
Pantheon site protocol scheme should match the db value regardless of request type.

## Notes for reviewers

None.

## Other Information

- [x] I updated the `README.md` file for any new/updated features.
- [x] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added
- Feature to disable WP_SITEURL and WP_HOME for Pantheon environments. This ensures the Pantheon site's protocol scheme matches the database values for `siteurl` and `home`, enhancing consistency across different request types. 

### Changed
- Manipulates protocol scheme for HTTP requests in Pantheon-maintains a `wp-config-pantheon.php` file to ensure site's domain protocol matches the protocol in the database options for `siteurl` and `home` for non-http requests as well. [#85](https://github.com/alleyinteractive/wp-alleyvate/issues/85)

### Deprecated

### Removed

### Fixed

### Security