### PR TITLE
Issue-42: [FEATURE] Disable deep pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Added
 
 * `disable_pantheon_constant_overrides`: Added a feature to disable forcing use of `WP_SITEURL` and `WP_HOME` on Pantheon environments.
+* `disable_deep_pagination`: Added a feature to restrict pagination to at most 100 pages, by default. This includes a filter `alleyvate_deep_pagination_max_pages` to override this limit, as well as a new `WP_Query` argument to override the limit: `__dangerously_set_max_pages`.
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,31 @@ This feature removes the custom fields meta box from the post editor.
 
 This feature removes clutter from the dashboard.
 
+### `disable_deep_pagination`
+
+This feature restricts pagination queries to, at most, 100 pages by default. This value is filterable using the `alleyvate_deep_pagination_max_pages` filter, or by passing the  `__dangerously_set_max_pages` argument to `WP_Query`.
+
+```php
+// An example.
+$query = new WP_Query(
+  [
+    'paged' => 102,
+    '__dangerously_set_max_pages' => 150,
+  ]
+);
+```
+
+### `disable_file_edit`
+
+This feature prevents the editing of themes and plugins directly from the admin.
+
+Such editing can introduce unexpected and undocumented code changes.
+
+### `disable_pantheon_constant_overrides`
+
+This feature prevents Pantheon environments from forcing CLI and Cron runs to use the `WP_HOME` or `WP_SITEURL` constants,
+which have been shown to force those environments to use an insecure protocol at times.
+
 ### `disable_password_change_notification`
 
 This feature disables sending password change notification emails to site admins.
@@ -68,16 +93,6 @@ This feature disables WordPress sticky posts entirely, including the ability to 
 
 This feature disables WordPress from sending or receiving trackbacks or pingbacks.
 
-### `disable_file_edit`
-
-This feature prevents the editing of themes and plugins directly from the admin.
-
-Such editing can introduce unexpected and undocumented code changes.
-
-### `disable_pantheon_constant_overrides`
-
-This feature prevents Pantheon environments from forcing CLI and Cron runs to use the `WP_HOME` or `WP_SITEURL` constants,
-which have been shown to force those environments to use an insecure protocol at times.
 
 ### `login_nonce`
 

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -14,6 +14,8 @@ namespace Alley\WP\Alleyvate\Features;
 
 use Alley\WP\Types\Feature;
 
+use WP_Query;
+
 /**
  * Disables Pagination beyond a filterable maximum. Beyond that return
  * a 400 error describing why the issue has arisen.
@@ -30,9 +32,9 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter the query to force no results if beyond page maximum.
 	 *
-	 * @param WP_Post[]|int[]|null $where    The posts array if set, null otherwise.
-	 * @param WP_Query             $wp_query The WP_Query object, passed by reference.
-	 * @return WP_Post[]|int[]|null
+	 * @param string   $where    The WHERE clause.
+	 * @param WP_Query $wp_query The WP_Query object, passed by reference.
+	 * @return string
 	 */
 	public static function filter__posts_where( $where, $wp_query ) {
 		$max_pages = ! empty( $wp_query->query['__dangerously_set_max_pages'] ) ? $wp_query->query['__dangerously_set_max_pages'] : 100;

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Class file for Disable_Deep_Pagination
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Disables Pagination beyond a filterable maximum. Beyond that return
+ * a 400 error describing why the issue has arisen.
+ */
+final class Disable_Deep_Pagination implements Feature {
+
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_filter( 'posts_where', [ self::class, 'filter__posts_where' ], 10, 2 );
+	}
+
+	/**
+	 * Filter the query to force no results if beyond page maximum.
+	 *
+	 * @param WP_Post[]|int[]|null $where    The posts array if set, null otherwise.
+	 * @param WP_Query             $wp_query The WP_Query object, passed by reference.
+	 * @return WP_Post[]|int[]|null
+	 */
+	public static function filter__posts_where( $where, $wp_query ) {
+		$max_pages = ! empty( $wp_query->query['__dangerously_set_max_pages'] ) ? $wp_query->query['__dangerously_set_max_pages'] : 100;
+
+		if (
+			is_admin() ||
+			(
+				wp_is_json_request() &&
+				is_user_logged_in()
+			) ||
+			empty( $wp_query->query['paged'] ) ||
+			$wp_query->query['paged'] <= apply_filters( 'alleyvate_deep_pagination_max_pages', $max_pages )
+		) {
+			return $where;
+		}
+
+		wp_die(
+			sprintf(
+				/* translators: The maximum number of pages. */
+				esc_html__( 'Invalid Request: Pagination beyond page %d has been disabled for performance reasons.', 'alley' ),
+				esc_html( $max_pages ),
+			),
+			esc_html__( 'Deep Pagination Disabled', 'alley' ),
+			400
+		);
+
+		return $where . 'AND 1 = 0';
+	}
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -88,7 +88,11 @@ function load(): void {
 		new Feature(
 			'disable_pantheon_constant_overrides',
 			new Features\Disable_Pantheon_Constant_Overrides(),
-		)
+		),
+		new Feature(
+			'disable_deep_pagination',
+			new Features\Disable_Deep_Pagination(),
+		),
 	);
 
 	$plugin->boot();

--- a/tests/alley/wp/alleyvate/features/test-disable-deep-pagination.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-deep-pagination.php
@@ -62,7 +62,7 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 		$this->admin_screen_tear_down();
 		unset( $GLOBALS['current_screen'] );
 
-		$this->handler = function() {
+		$this->handler = function () {
 			return fn( $message, $title, $args ) => self::assertSame( 400, $args['response'] );
 		};
 
@@ -99,21 +99,12 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 		// Make sure we are actually filtering where.
 		self::assertFalse( is_admin() );
 
-		try {
-			new WP_Query(
-				[
-					'posts_per_page' => 1,
-					'paged'          => 101,
-				]
-			);
-		} catch ( WP_Die_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-
-			/*
-			 * Intentionally left blank. Assertions happen
-			 * in the WP_Die_Exception handler.
-			 */
-
-		}
+		new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'paged'          => 101,
+			]
+		);
 	}
 
 	/**
@@ -152,21 +143,12 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 		// Make sure we are actually filtering where.
 		self::assertFalse( is_admin() );
 
-		try {
-			new WP_Query(
-				[
-					'posts_per_page' => 1,
-					'paged'          => 101,
-				]
-			);
-		} catch ( WP_Die_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-
-			/*
-			 * Intentionally left blank. Assertions happen
-			 * in the WP_Die_Exception handler.
-			 */
-
-		}
+		new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'paged'          => 101,
+			]
+		);
 
 		$this->filter_max_pages( 101 );
 
@@ -238,12 +220,8 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 	public function test_unauthenticated_rest_queries_are_filtered() {
 		$this->feature->boot();
 
-		try {
-			$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
-				->assertExactJson( [] );
-		} catch ( Exception $e ) {
-
-		}
+		$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
+			->assertExactJson( [] );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
 			->get_content();
@@ -261,13 +239,10 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 
 		$this->acting_as( 'administrator' );
 
-		try {
-			$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
-				->get_content();
-		} catch ( Exception $e ) {}
+		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
+			->get_content();
 
 		$this->assertCount( 1, json_decode( $body ) );
-
 	}
 
 	/**
@@ -285,7 +260,7 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 			return;
 		}
 
-		$this->filter = function() use ( $max ) {
+		$this->filter = function () use ( $max ) {
 			return $max;
 		};
 

--- a/tests/alley/wp/alleyvate/features/test-disable-deep-pagination.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-deep-pagination.php
@@ -17,9 +17,7 @@ namespace Alley\WP\Alleyvate\Features;
 use Mantle\Testing\Concerns\Admin_Screen;
 use Mantle\Testkit\Test_Case;
 use Mantle\Testing\Concerns\Refresh_Database;
-use Mantle\Testing\Exceptions\WP_Die_Exception;
 use WP_Query;
-use WP_REST_Request;
 
 /**
  * Tests for fully disabling comment functionality.
@@ -66,8 +64,8 @@ final class Test_Disable_Deep_Pagination extends Test_Case {
 			return fn( $message, $title, $args ) => self::assertSame( 400, $args['response'] );
 		};
 
-		add_filter( 'wp_die_handler', $this->handler, PHP_INT_MAX );
-		add_filter( 'wp_die_json_handler', $this->handler, PHP_INT_MAX );
+		add_filter( 'wp_die_handler', $this->handler, \PHP_INT_MAX );
+		add_filter( 'wp_die_json_handler', $this->handler, \PHP_INT_MAX );
 
 		$this->feature = new Disable_Deep_Pagination();
 	}

--- a/tests/alley/wp/alleyvate/features/test-disable-deep-pagination.php
+++ b/tests/alley/wp/alleyvate/features/test-disable-deep-pagination.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Class file for Test_Disable_Deep_Pagination
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+declare( strict_types=1 );
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Mantle\Testing\Concerns\Admin_Screen;
+use Mantle\Testkit\Test_Case;
+use Mantle\Testing\Concerns\Refresh_Database;
+use Mantle\Testing\Exceptions\WP_Die_Exception;
+use WP_Query;
+use WP_REST_Request;
+
+/**
+ * Tests for fully disabling comment functionality.
+ */
+final class Test_Disable_Deep_Pagination extends Test_Case {
+	use Refresh_Database;
+	use Admin_Screen;
+
+	/**
+	 * Feature instance.
+	 *
+	 * @var Disable_Deep_Pagination
+	 */
+	private Disable_Deep_Pagination $feature;
+
+	/**
+	 * Filter function for max number of pages.
+	 *
+	 * @var callable|null
+	 */
+	private $filter = null;
+
+	/**
+	 * The wp_die_handler callable.
+	 *
+	 * @var callable|null
+	 */
+	private $handler = null;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Generate 101 posts to use in testing.
+		self::factory()->post->create_ordered_set( 150 );
+
+		// Disable the Admin screen for now.
+		$this->admin_screen_tear_down();
+		unset( $GLOBALS['current_screen'] );
+
+		$this->handler = function() {
+			return fn( $message, $title, $args ) => self::assertSame( 400, $args['response'] );
+		};
+
+		add_filter( 'wp_die_handler', $this->handler, PHP_INT_MAX );
+		add_filter( 'wp_die_json_handler', $this->handler, PHP_INT_MAX );
+
+		$this->feature = new Disable_Deep_Pagination();
+	}
+
+	/**
+	 * Tear Down.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		unset( $GLOBALS['current_screen'] );
+		if ( ! empty( $this->filter ) ) {
+			remove_filter( 'alleyvate_deep_pagination_max_pages', $this->filter );
+		}
+
+		if ( ! empty( $this->handler ) ) {
+			remove_filter( 'wp_die_handler', $this->handler );
+			remove_filter( 'wp_die_json_handler', $this->handler );
+		}
+	}
+
+	/**
+	 * Verify the maximum pages are listed at 100.
+	 *
+	 * @test
+	 */
+	public function test_maximum_posts_restricted() {
+		$this->feature->boot();
+
+		// Make sure we are actually filtering where.
+		self::assertFalse( is_admin() );
+
+		try {
+			new WP_Query(
+				[
+					'posts_per_page' => 1,
+					'paged'          => 101,
+				]
+			);
+		} catch ( WP_Die_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+
+			/*
+			 * Intentionally left blank. Assertions happen
+			 * in the WP_Die_Exception handler.
+			 */
+
+		}
+	}
+
+	/**
+	 * Do not filter WP Admin queries.
+	 *
+	 * @test
+	 */
+	public function test_admin_queries_are_unaffected() {
+		// Enable the Admin screen.
+		$this->admin_screen_set_up();
+		$this->feature->boot();
+
+		$this->acting_as( 'administrator' );
+
+		self::assertTrue( is_admin() );
+
+		$query = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'paged'          => 101,
+			]
+		);
+
+		self::assertTrue( $query->have_posts() );
+	}
+
+	/**
+	 * Allow filtering of the maximum number of posts.
+	 *
+	 * @test
+	 */
+	public function test_maximum_number_of_posts_can_be_filtered() {
+		// Enable the Admin screen.
+		$this->feature->boot();
+
+		// Make sure we are actually filtering where.
+		self::assertFalse( is_admin() );
+
+		try {
+			new WP_Query(
+				[
+					'posts_per_page' => 1,
+					'paged'          => 101,
+				]
+			);
+		} catch ( WP_Die_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+
+			/*
+			 * Intentionally left blank. Assertions happen
+			 * in the WP_Die_Exception handler.
+			 */
+
+		}
+
+		$this->filter_max_pages( 101 );
+
+		$query = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'paged'          => 101,
+			]
+		);
+
+		self::assertTrue( $query->have_posts() );
+	}
+
+	/**
+	 * Validate that all expected pages can be accessed.
+	 *
+	 * @test
+	 */
+	public function test_all_expected_available_pages_can_be_accessed() {
+		// Enable the Admin screen.
+		$this->feature->boot();
+
+		// Make sure we are actually filtering where.
+		self::assertFalse( is_admin() );
+
+		$this->filter_max_pages( 5 );
+
+		for ( $paged = 1; $paged <= 5; $paged++ ) {
+			$query = new WP_Query(
+				[
+					'posts_per_page' => 1,
+					'paged'          => $paged,
+				]
+			);
+
+			self::assertTrue( $query->have_posts() );
+		}
+	}
+
+	/**
+	 * We should allow developers to dangerously override this filter in code, when necessary, as a
+	 * one-time override of the filter. This will allow us to not have to litter our code with hundreds
+	 * of one-time-use filters.
+	 *
+	 * @test
+	 */
+	public function test_can_dangerously_override_page_limit() {
+		$this->feature->boot();
+
+		// Make sure we are actually filtering where.
+		self::assertFalse( is_admin() );
+
+		$query = new WP_Query(
+			[
+				'posts_per_page'              => 1,
+				'paged'                       => 101,
+				'__dangerously_set_max_pages' => 101,
+			]
+		);
+
+		self::assertTrue( $query->have_posts() );
+	}
+
+	/**
+	 * Unauthenticated REST queries should be filtered.
+	 *
+	 * @test
+	 */
+	public function test_unauthenticated_rest_queries_are_filtered() {
+		$this->feature->boot();
+
+		try {
+			$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
+				->assertExactJson( [] );
+		} catch ( Exception $e ) {
+
+		}
+
+		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
+			->get_content();
+
+		$this->assertCount( 1, json_decode( $body ) );
+	}
+
+	/**
+	 * Authenticated REST queries should NOT be filtered.
+	 *
+	 * @test
+	 */
+	public function test_authenticated_rest_queries_are_not_filtered() {
+		$this->feature->boot();
+
+		$this->acting_as( 'administrator' );
+
+		try {
+			$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
+				->get_content();
+		} catch ( Exception $e ) {}
+
+		$this->assertCount( 1, json_decode( $body ) );
+
+	}
+
+	/**
+	 * Helper function for swapping out the max pages filter.
+	 *
+	 * @param int $max The max pages to return.
+	 */
+	private function filter_max_pages( int $max ): void {
+		if ( ! empty( $this->filter ) ) {
+			remove_filter( 'alleyvate_deep_pagination_max_pages', $this->filter );
+		}
+
+		if ( 0 >= $max ) {
+			$this->filter = null;
+			return;
+		}
+
+		$this->filter = function() use ( $max ) {
+			return $max;
+		};
+
+		add_filter( 'alleyvate_deep_pagination_max_pages', $this->filter );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #42 

As titled. This update disables deep pagination beyond page 100 for both frontend and unauthenticated REST requests, with added flexibility to customize this limit.

## Notes for reviewers

Please review the implementation of the deep pagination disable feature and note the adjustments for coding standards compliance.

## Other Information

- [x] I updated the `README.md` file for any new/updated features.
- [x] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added
- Disable pagination past page 100 for frontend and unauthenticated REST requests. Allow customization of the limit. [#42](https://github.com/alleyinteractive/wp-alleyvate/issues/42)

### Changed

### Deprecated

### Removed

### Fixed
- Addressed PHPCS issues related to the deep pagination feature.

### Security