### PR TITLE
Issue-55: [FEATURE] Force 2FA for All Users Who Can Edit Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Added
 
 * `disable_pantheon_constant_overrides`: Added a feature to disable forcing use of `WP_SITEURL` and `WP_HOME` on Pantheon environments.
+* `force_two_factor_authentication`: Added a feature to force Two Factor Authentication for users with `edit_posts` permissions.
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ This feature disables WordPress sticky posts entirely, including the ability to 
 
 This feature disables WordPress from sending or receiving trackbacks or pingbacks.
 
-
 ### `force_two_factor_authentication`
 
 This feature forces users with `edit_posts` permissions to use two factor authentication (2fa) for their accounts.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Such editing can introduce unexpected and undocumented code changes.
 This feature prevents Pantheon environments from forcing CLI and Cron runs to use the `WP_HOME` or `WP_SITEURL` constants,
 which have been shown to force those environments to use an insecure protocol at times.
 
+### `force_two_factor_authentication`
+
+This feature forces users with `edit_posts` permissions to use two factor authentication (2fa) for their accounts.
+
 ### `login_nonce`
 
 This feature adds a nonce to the login form to prevent CSRF attacks.

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -49,10 +49,11 @@ final class Force_Two_Factor_Authentication implements Feature {
 	/**
 	 * Filter the user capabilities to restrict them to just those capabilities required to enabled two factor authentication.
 	 *
-	 * @param array  $caps    The user capabilities.
-	 * @param string $cap     The currently active user capability.
-	 * @param int    $user_id The user ID.
-	 * @param array  $args    Context to the capability check.
+	 * @param array<string> $caps    The user capabilities.
+	 * @param string        $cap     The currently active user capability.
+	 * @param int           $user_id The user ID.
+	 * @param array<mixed>  $args    Context to the capability check.
+	 * @return array<string>
 	 */
 	public static function filter__map_meta_cap( $caps, $cap, $user_id, $args ): array {
 		if ( ! self::should_use_two_factor_authentication() ) {
@@ -67,7 +68,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 		if (
 			'edit_user' === $cap &&
 			! empty( $args ) &&
-			(int) $user_id === (int) $args[0]
+			(int) $user_id === (int) $args[0] // @phpstan-ignore-line
 		) {
 			$subscriber_caps[] = 'edit_user';
 		}
@@ -184,7 +185,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 	 * @return bool
 	 */
 	private static function two_factor_already_in_use(): bool {
-		return self::two_factor_plugin_active() && \Two_Factor_Core::is_user_using_two_factor();
+		return self::two_factor_plugin_active() && \Two_Factor_Core::is_user_using_two_factor(); // @phpstan-ignore-line
 	}
 
 	/**

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -43,7 +43,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 	 * @return bool
 	 */
 	public static function filter__wpcom_vip_is_two_factor_forced(): bool {
-		return current_user_can( 'edit_posts' );
+		return self::force_to_enable_2fa();
 	}
 
 	/**
@@ -160,14 +160,16 @@ final class Force_Two_Factor_Authentication implements Feature {
 	 * @return bool
 	 */
 	private static function force_to_enable_2fa(): bool {
-		$capability_min = apply_filters( 'alleyvate_force_2fa_capability', 'publish_posts' );
+		$capability_min = apply_filters( 'alleyvate_force_2fa_capability', 'edit_posts' );
 
 		// Remove the filter to avoid infinite loops.
-		remove_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0 );
+		$removed = remove_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0 );
 
 		$result = current_user_can( $capability_min );
 
-		add_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0, 4 );
+		if ( $removed ) {
+			add_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0, 4 );
+		}
 
 		return $result;
 	}

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -139,6 +139,10 @@ final class Force_Two_Factor_Authentication implements Feature {
 	/**
 	 * Returns true if Two Factor Authentication should be enforced, false otherwise.
 	 *
+	 * This will be false if the environment is a local environment, if the user is not
+	 * logged in, if the Two Factor plugin is not activated, or if the Two Factor plugin
+	 * is active and 2fa is already enabled for this user account.
+	 *
 	 * @return bool
 	 */
 	private static function should_use_two_factor_authentication(): bool {
@@ -151,7 +155,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 				is_user_logged_in() &&
 				self::force_to_enable_2fa() &&
 				self::two_factor_plugin_active() &&
-				! self::two_factor_plugin_in_use();
+				! self::two_factor_already_in_use();
 	}
 
 	/**
@@ -175,19 +179,16 @@ final class Force_Two_Factor_Authentication implements Feature {
 	}
 
 	/**
-	 * Returns true if the user is using the Two Factor plugin already.
+	 * Returns true if the user is using the Two Factor plugin, and 2fa is already enabled for the user.
 	 *
 	 * @return bool
 	 */
-	private static function two_factor_plugin_in_use(): bool {
+	private static function two_factor_already_in_use(): bool {
 		return self::two_factor_plugin_active() && \Two_Factor_Core::is_user_using_two_factor();
 	}
 
 	/**
-	 * Returns true if:
-	 *   - The environment is not VIP.
-	 *   - Jetpack SSO with 2FA is not enabled.
-	 *   - The Two Factor plugin is not found.
+	 * Determine if the Two Factor plugin is activated.
 	 *
 	 * @return bool
 	 */
@@ -196,7 +197,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 	}
 
 	/**
-	 * Is this environment a VIP environment?
+	 * Determine if the site is loaded in a VIP environment.
 	 *
 	 * @return bool
 	 */

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class file for Force_Two_Factor_Authentication
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Forces 2FA for users with Edit permissions or higher when 2FA is available.
+ */
+final class Force_Two_Factor_Authentication implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+
+	}
+}

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -31,9 +31,9 @@ final class Force_Two_Factor_Authentication implements Feature {
 		}
 
 		// For non-VIP environments, we do the forcing ourselves.
-		add_filter( 'map_meta_cap', [ static::class, 'filter__map_meta_cap' ], 0, 4 );
+		add_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0, 4 );
 
-		add_action( 'admin_notices', [ static::class, 'action__admin_notices' ] );
+		add_action( 'admin_notices', [ self::class, 'action__admin_notices' ] );
 	}
 
 	/**
@@ -163,11 +163,11 @@ final class Force_Two_Factor_Authentication implements Feature {
 		$capability_min = apply_filters( 'alleyvate_force_2fa_capability', 'publish_posts' );
 
 		// Remove the filter to avoid infinite loops.
-		remove_filter( 'map_meta_cap', [ static::class, 'filter__map_meta_cap' ], 0 );
+		remove_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0 );
 
 		$result = current_user_can( $capability_min );
 
-		add_filter( 'map_meta_cap', [ static::class, 'filter__map_meta_cap' ], 0, 4 );
+		add_filter( 'map_meta_cap', [ self::class, 'filter__map_meta_cap' ], 0, 4 );
 
 		return $result;
 	}

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -16,12 +16,189 @@ use Alley\WP\Types\Feature;
 
 /**
  * Forces 2FA for users with Edit permissions or higher when 2FA is available.
+ *
+ * A lot of this is inspired by Automattic's checks for VIP Go.
  */
 final class Force_Two_Factor_Authentication implements Feature {
+
 	/**
 	 * Boot the feature.
 	 */
 	public function boot(): void {
+		if ( self::is_vip_environment() ) {
+			add_filter( 'wpcom_vip_is_two_factor_forced', [ self::class, 'filter__wpcom_vip_is_two_factor_forced' ], PHP_INT_MAX );
+			return;
+		}
 
+		// For non-VIP environments, we do the forcing ourselves.
+		add_filter( 'map_meta_cap', [ static::class, 'filter__map_meta_cap' ], 0, 4 );
+
+		add_action( 'admin_notices', [ static::class, 'action__admin_notices' ] );
+	}
+
+	/**
+	 * For VIP environments we can skip all of the functionality, and only focus on returning true if the current user
+	 * can edit posts.
+	 *
+	 * @return bool
+	 */
+	public static function filter__wpcom_vip_is_two_factor_forced(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Filter the user capabilities to restrict them to just those capabilities required to enabled two factor authentication.
+	 *
+	 * @param array  $caps    The user capabilities.
+	 * @param string $cap     The currently active user capability.
+	 * @param int    $user_id The user ID.
+	 * @param array  $args    Context to the capability check.
+	 */
+	public static function filter__map_meta_cap( $caps, $cap, $user_id, $args ): array {
+		if ( ! self::should_use_two_factor_authentication() ) {
+			return $caps;
+		}
+
+		$subscriber_caps = [
+			'read',
+			'level_0',
+		];
+
+		if (
+			'edit_user' === $cap &&
+			! empty( $args ) &&
+			(int) $user_id === (int) $args[0]
+		) {
+			$subscriber_caps[] = 'edit_user';
+		}
+
+		return in_array( $cap, $subscriber_caps, true ) ? $caps : [ 'do_not_allow' ];
+	}
+
+	/**
+	 * Adds admin notices for the end user.
+	 */
+	public static function action__admin_notices(): void {
+		if ( self::should_use_two_factor_authentication() ) {
+			self::admin_notice__configure_two_factor();
+		}
+
+		if ( ! self::two_factor_plugin_active() ) {
+			self::admin_notice__plugin_dependency();
+		}
+	}
+
+	/**
+	 * Adds an Admin Notice notifying the end user that they need to enable Two Factor authentication.
+	 */
+	public static function admin_notice__configure_two_factor(): void {
+		?>
+		<div class="notice notice-error">
+			<p>
+				<strong><?php esc_html_e( 'Two-factor authentication is required.', 'alley' ); ?></strong>
+				<?php
+					printf(
+						wp_kses_post(
+							/* translators: The Admin URL to the profile page. */
+							__( 'Please <a href="%s">set up two-factor authentication</a> to continue.', 'alley' )
+						),
+						esc_url( admin_url( 'profile.php' ) )
+					);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Adds an Admin Notice notifying administrators that they need to install the Two Factor authentication plugin.
+	 * Only show to users who can activate plugins.
+	 */
+	public static function admin_notice__plugin_dependency(): void {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+		?>
+		<div class="notice notice-error">
+			<p>
+				<strong><?php esc_html_e( 'Two-factor authentication plugin is required.', 'alley' ); ?></strong>
+				<?php
+					printf(
+						wp_kses_post(
+							/* translators: The URL to the Two Factor plugin in the WordPress.org repository. */
+							__( 'Please install the <a href="%s">Two Factor plugin</a> to enable this feature.', 'alley' )
+						),
+						esc_url( 'https://wordpress.org/plugins/two-factor/' )
+					);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Returns true if Two Factor Authentication should be enforced, false otherwise.
+	 *
+	 * @return bool
+	 */
+	private static function should_use_two_factor_authentication(): bool {
+		/*
+		 * Ignore 2fa for local environments, not logged in users, or VIP environments.
+		 *
+		 * Also don't try to enforce 2fa if we don't have the Two Factor plugin installed.
+		 */
+		return 'local' !== wp_get_environment_type() &&
+				is_user_logged_in() &&
+				self::force_to_enable_2fa() &&
+				self::two_factor_plugin_active() &&
+				! self::two_factor_plugin_in_use();
+	}
+
+	/**
+	 * Determine whether the user should be forced to enable 2fa before interacting with site.
+	 *
+	 * @return bool
+	 */
+	private static function force_to_enable_2fa(): bool {
+		$capability_min = apply_filters( 'alleyvate_force_2fa_capability', 'publish_posts' );
+
+		// Remove the filter to avoid infinite loops.
+		remove_filter( 'map_meta_cap', [ static::class, 'filter__map_meta_cap' ], 0 );
+
+		$result = current_user_can( $capability_min );
+
+		add_filter( 'map_meta_cap', [ static::class, 'filter__map_meta_cap' ], 0, 4 );
+
+		return $result;
+	}
+
+	/**
+	 * Returns true if the user is using the Two Factor plugin already.
+	 *
+	 * @return bool
+	 */
+	private static function two_factor_plugin_in_use(): bool {
+		return self::two_factor_plugin_active() && \Two_Factor_Core::is_user_using_two_factor();
+	}
+
+	/**
+	 * Returns true if:
+	 *   - The environment is not VIP.
+	 *   - Jetpack SSO with 2FA is not enabled.
+	 *   - The Two Factor plugin is not found.
+	 *
+	 * @return bool
+	 */
+	private static function two_factor_plugin_active(): bool {
+		return class_exists( 'Two_Factor_Core' );
+	}
+
+	/**
+	 * Is this environment a VIP environment?
+	 *
+	 * @return bool
+	 */
+	private static function is_vip_environment(): bool {
+		return defined( 'VIP_GO_APP_ENVIRONMENT' );
 	}
 }

--- a/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
+++ b/src/alley/wp/alleyvate/features/class-force-two-factor-authentication.php
@@ -26,7 +26,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 	 */
 	public function boot(): void {
 		if ( self::is_vip_environment() ) {
-			add_filter( 'wpcom_vip_is_two_factor_forced', [ self::class, 'filter__wpcom_vip_is_two_factor_forced' ], PHP_INT_MAX );
+			add_filter( 'wpcom_vip_is_two_factor_forced', [ self::class, 'filter__wpcom_vip_is_two_factor_forced' ], \PHP_INT_MAX );
 			return;
 		}
 
@@ -73,7 +73,7 @@ final class Force_Two_Factor_Authentication implements Feature {
 			$subscriber_caps[] = 'edit_user';
 		}
 
-		return in_array( $cap, $subscriber_caps, true ) ? $caps : [ 'do_not_allow' ];
+		return \in_array( $cap, $subscriber_caps, true ) ? $caps : [ 'do_not_allow' ];
 	}
 
 	/**
@@ -203,6 +203,6 @@ final class Force_Two_Factor_Authentication implements Feature {
 	 * @return bool
 	 */
 	private static function is_vip_environment(): bool {
-		return defined( 'VIP_GO_APP_ENVIRONMENT' );
+		return \defined( 'VIP_GO_APP_ENVIRONMENT' );
 	}
 }

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -88,6 +88,10 @@ function load(): void {
 		new Feature(
 			'disable_pantheon_constant_overrides',
 			new Features\Disable_Pantheon_Constant_Overrides(),
+		),
+		new Feature(
+			'force_two_factor_authentication',
+			new Features\Force_Two_Factor_Authentication(),
 		)
 	);
 

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -93,7 +93,7 @@ function load(): void {
 			'force_two_factor_authentication',
 			new Features\Force_Two_Factor_Authentication(),
 		),
-    new Feature(
+		new Feature(
 			'disable_deep_pagination',
 			new Features\Disable_Deep_Pagination(),
 		),


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Other Information

- [x] I updated the `README.md` file for any new/updated features.
- [x] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added
- Force 2FA for all users who can edit content on WordPress VIP sites, sites that use Jetpack, and sites that use the Two Factor plugin. [#55](https://github.com/alleyinteractive/wp-alleyvate/issues/55)

### Changed

### Deprecated

### Removed

### Fixed

### Security
- Implemented a security measure requiring users to set up Two-Factor Authentication (2FA) before being able to edit anything other than their profile. This measure is aimed at enhancing the security of WordPress VIP sites, Jetpack-enabled sites, and sites using the Two Factor plugin. References to Jetpack and VIP's 2FA implementation were considered during the discussion. [#55](https://github.com/alleyinteractive/wp-alleyvate/issues/55)
