### PR TITLE
Disable attachment redirects to files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 3.4.0
+
+### Changed
+
+* The `disable_attachment_routing` feature now also disables the automatic redirect from an attachment to its corresponding file URL.
+
 ## 3.3.0
 
 ### Added


### PR DESCRIPTION
## Summary

The previous implementation, on `pre_get_posts`, ran too early to prevent this redirect. It was still possible for a query to be set to `is_attachment` after `pre_get_posts` ([example](https://github.com/WordPress/wordpress-develop/blob/1e21ecedf19f1b97360949a9e509a3c04ac1f34e/src/wp-includes/class-wp-query.php#L2175-L2179)), and that was enough to trigger the redirect to the attachment URL in `redirect_canonical()` ([source](https://github.com/WordPress/wordpress-develop/blob/1e21ecedf19f1b97360949a9e509a3c04ac1f34e/src/wp-includes/canonical.php#L552-L571)). 

In the approach taken here, the query is allowed to complete normally, determining conditionals like `is_attachment`, before being inspected and overridden later if necessary.

## Notes for reviewers

None.

## Other Information

- [x] I updated the `README.md` file for any new/updated features.
- [x] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Changed

* The `disable_attachment_routing` feature now also disables the automatic redirect from an attachment to its corresponding file URL.
