### PR TITLE
Issue-70: Bug: Login Nonce fails for pages \"cached\" by bfcache

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           php-version: '${{ matrix.php }}'
           skip-audit: 'true'
-          skip-wordpress-install: 'true'
           wordpress-version: '${{ matrix.wordpress }}'
           wordpress-multisite: '${{ matrix.multisite }}'
+          skip-core-test-suite: 'true'
+          skip-wordpress-install: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+* `login_nonce`: Fixed issue where loading cached version of login page would store invalid nonce.
+
 ## 3.4.0
 
 ### Changed

--- a/src/alley/wp/alleyvate/features/class-login-nonce.php
+++ b/src/alley/wp/alleyvate/features/class-login-nonce.php
@@ -135,10 +135,7 @@ final class Login_Nonce implements Feature {
 
 		$nonce = sanitize_key( $_POST[ self::NONCE_NAME ] ?? '' );
 
-		if (
-			! $nonce ||
-			! wp_verify_nonce( $nonce, self::NONCE_ACTION )
-		) {
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
 			// This is a login with an invalid nonce. Throw an error.
 			http_response_code( 403 );
 			wp_die( 'Login attempt failed. Please try again.', 'Login Error' );


### PR DESCRIPTION
## Summary

As titled. Fixes #70

## Notes for reviewers

None.

## Other Information

- [ ] I updated the `README.md` file for any new/updated features.
- [ ] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added
- Refresh mechanism for persisted pages to ensure nonce validation.

### Changed

### Deprecated

### Removed
- Unnecessary nonce validation check that failed for empty values.

### Fixed

### Security