### PR TITLE
On login nonce failure, redirect to login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 * `noindex_password_protected_posts`: Added a feature to add noindex to the robots meta tag content for password-protected posts.
 
+### Changed
+
+* On login nonce failure, redirect back to the login page with an error message.
+
 ## 3.6.0
 
 ### Added

--- a/tests/Alley/WP/Alleyvate/Features/LoginNonceTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/LoginNonceTest.php
@@ -82,13 +82,14 @@ final class LoginNonceTest extends Test_Case {
 
 		$pagenow = 'wp-login.php';
 
+		// Prevent the redirect and exit from firing.
+		add_filter( 'wp_redirect', fn( $location ) => wp_die( esc_url( $location ) ) );
+
 		try {
 			Login_Nonce::action__pre_validate_login_nonce();
 		} catch ( WP_Die_Exception $e ) {
-			$this->assertSame( 'Login attempt failed. Please try again.', $e->getMessage() );
+			$this->assertSame( wp_login_url() . '?action=expired', $e->getMessage() );
 		}
-
-		$this->assertSame( 403, http_response_code() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Other Information

- [ ] I updated the `README.md` file for any new/updated features.
- [x] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added

### Changed

* On login nonce failure, redirect back to the login page with an error message.

### Deprecated

### Removed

### Fixed

### Security
