### PR TITLE
Pagination max should be 100 and error 410

### DIFF
--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -52,8 +52,8 @@ final class Disable_Deep_Pagination implements Feature {
 			return $where;
 		}
 
+		// If this is a JSON request, and the user is not logged in, we need to return a 400 error.
 		if ( wp_is_json_request() ) {
-			// If this is a JSON request, and the user is not logged in, we need to return a 400 error.
 			wp_die(
 				\sprintf(
 					/* translators: The maximum number of pages. */
@@ -63,7 +63,6 @@ final class Disable_Deep_Pagination implements Feature {
 				esc_html__( 'Deep Pagination Disabled', 'alley' ),
 				400
 			);
-
 		}
 
 		// Set the HTTP response status code to 410.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -62,9 +62,9 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter post results to force page maximum.
 	 *
-	 * @param array    $posts    The posts.
+	 * @param WP_Post[]    $posts    The posts.
 	 * @param WP_Query $wp_query The WP_Query object, passed by reference.
-	 * @return array
+	 * @return WP_Post[]
 	 */
 	public static function filter__posts_results( array $posts, WP_Query $wp_query ): array {
 		// If this is an admin request, or a JSON request with a logged in user, return the posts as normal.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -68,9 +68,9 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter the context for the query-pagination blocks.
 	 *
-	 * @param array $context The block context.
-	 * @param array $block   The block data.
-	 * @return array
+	 * @param array<string, mixed> $block The block data.
+     * @param array<string, mixed> $context The context data.
+     * @return array<string, mixed> The pagination data.
 	 */
 	public static function render_block_context_query_pagination( array $context, array $block ): array {
 		global $wp_query;

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -27,7 +27,7 @@ final class Disable_Deep_Pagination implements Feature {
 	 */
 	public function boot(): void {
 		add_filter( 'posts_where', [ self::class, 'filter__posts_where' ], 10, 2 );
-		add_filter( 'render_block_context', [ self::class, 'render_block_context_query_pagination_numbers' ], 10, 2 );
+		add_filter( 'render_block_context', [ self::class, 'render_block_context_query_pagination' ], 10, 2 );
 	}
 
 	/**
@@ -66,17 +66,17 @@ final class Disable_Deep_Pagination implements Feature {
 	}
 
 	/**
-	 * Filter the context for the query-pagination-numbers block.
+	 * Filter the context for the query-pagination blocks.
 	 *
 	 * @param array $context The block context.
 	 * @param array $block   The block data.
 	 * @return array
 	 */
-	public static function render_block_context_query_pagination_numbers( array $context, array $block ): array {
+	public static function render_block_context_query_pagination( array $context, array $block ): array {
 		global $wp_query;
 
-		// Check if the block is the query-pagination-numbers block.
-		if ( $block['blockName'] === 'core/query-pagination-numbers' ) {
+		// Check if the block is one of the query-pagination blocks.
+		if ( str_starts_with( $block['blockName'], 'core/query-pagination' ) ) {
 			// Set the max pages to the value from the query or a default value.
 			$max_pages = ! empty( $wp_query->query['__dangerously_set_max_pages'] ) ? $wp_query->query['__dangerously_set_max_pages'] : 100;
 			// Set the max pages in the context.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -76,10 +76,13 @@ final class Disable_Deep_Pagination implements Feature {
 		global $wp_query;
 
 		// Check if the block is one of the query-pagination blocks.
-		if ( str_starts_with( $block['blockName'], 'core/query-pagination' ) ) {
+		if ( isset( $block['blockName'] ) && is_string( $block['blockName'] ) && str_starts_with( $block['blockName'], 'core/query-pagination' ) ) {
 			// Set the max pages to the value from the query or a default value.
 			$max_pages = ! empty( $wp_query->query['__dangerously_set_max_pages'] ) ? $wp_query->query['__dangerously_set_max_pages'] : 100;
 			// Set the max pages in the context.
+			if ( ! isset( $context['query'] ) || ! is_array( $context['query'] ) ) {
+				$context['query'] = [];
+			}
 			$context['query']['pages'] = apply_filters( 'alleyvate_deep_pagination_max_pages', $max_pages );
 		}
 

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -68,9 +68,9 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter the context for the query-pagination blocks.
 	 *
-	 * @param array<string, mixed> $block The block data.
-     * @param array<string, mixed> $context The context data.
-     * @return array<string, mixed> The pagination data.
+	 * @param array<string, mixed> $context The block data.
+	 * @param array<string, mixed> $block   The context data.
+	 * @return array<string, mixed> The pagination data.
 	 */
 	public static function render_block_context_query_pagination( array $context, array $block ): array {
 		global $wp_query;

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -53,9 +53,9 @@ final class Disable_Deep_Pagination implements Feature {
 		}
 
 		// Set the HTTP response status code to 410.
-		status_header(410);
+		status_header( 410 );
 		// Load the 404 template.
-		include( get_404_template() );
+		include get_404_template();
 		return $where . 'AND 1 = 0';
 	}
 

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -27,7 +27,7 @@ final class Disable_Deep_Pagination implements Feature {
 	 */
 	public function boot(): void {
 		add_filter( 'posts_where', [ self::class, 'filter__posts_where' ], 10, 2 );
-		add_filter( 'render_block_context', [ self::class, 'custom_query_pagination_context' ], 10, 2 );
+		add_filter( 'render_block_context', [ self::class, 'render_block_context_query_pagination_numbers' ], 10, 2 );
 	}
 
 	/**
@@ -72,7 +72,7 @@ final class Disable_Deep_Pagination implements Feature {
 	 * @param array $block   The block data.
 	 * @return array
 	 */
-	public static function custom_query_pagination_context( array $context, array $block ): array {
+	public static function render_block_context_query_pagination_numbers( array $context, array $block ): array {
 		global $wp_query;
 
 		// Check if the block is the query-pagination-numbers block.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -53,11 +53,10 @@ final class Disable_Deep_Pagination implements Feature {
 		}
 
 		// Set the HTTP response status code to 410.
-		status_header( 410 );
+		status_header(410);
 		// Load the 404 template.
-		include get_404_template();
-		// Terminate the script execution.
-		exit;
+		include( get_404_template() );
+		return $where . 'AND 1 = 0';
 	}
 
 	/**

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -27,6 +27,7 @@ final class Disable_Deep_Pagination implements Feature {
 	 */
 	public function boot(): void {
 		add_filter( 'posts_where', [ self::class, 'filter__posts_where' ], 10, 2 );
+		add_filter( 'render_block_context', [ self::class, 'custom_query_pagination_context' ], 10, 2 );
 	}
 
 	/**
@@ -36,7 +37,7 @@ final class Disable_Deep_Pagination implements Feature {
 	 * @param WP_Query $wp_query The WP_Query object, passed by reference.
 	 * @return string
 	 */
-	public static function filter__posts_where( $where, $wp_query ) {
+	public static function filter__posts_where( string $where, WP_Query $wp_query ): string {
 		$max_pages = ! empty( $wp_query->query['__dangerously_set_max_pages'] ) ? $wp_query->query['__dangerously_set_max_pages'] : 100;
 
 		if (

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -52,6 +52,20 @@ final class Disable_Deep_Pagination implements Feature {
 			return $where;
 		}
 
+		if ( wp_is_json_request() ) {
+			// If this is a JSON request, and the user is not logged in, we need to return a 400 error.
+			wp_die(
+				\sprintf(
+					/* translators: The maximum number of pages. */
+					esc_html__( 'Invalid Request: Pagination beyond page %d has been disabled for performance reasons.', 'alley' ),
+					esc_html( $max_pages ),
+				),
+				esc_html__( 'Deep Pagination Disabled', 'alley' ),
+				400
+			);
+
+		}
+
 		// Set the HTTP response status code to 410.
 		status_header( 410 );
 		// Load the 404 template.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -60,7 +60,7 @@ final class Disable_Deep_Pagination implements Feature {
 	}
 
 	/**
-	 * Filter post results to force page maximum.
+	 * Filter post results to force max num of pages.
 	 *
 	 * @param WP_Post[] $posts    The posts.
 	 * @param WP_Query  $wp_query The WP_Query object, passed by reference.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -62,9 +62,9 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter post results to force max num of pages.
 	 *
-	 * @param array<WP_Post> $posts    The posts.
-	 * @param WP_Query       $wp_query The WP_Query object, passed by reference.
-	 * @return array<WP_Post>
+	 * @param array<\WP_Post> $posts    The posts.
+	 * @param WP_Query        $wp_query The WP_Query object, passed by reference.
+	 * @return array<\WP_Post>
 	 */
 	public static function filter__posts_results( array $posts, WP_Query $wp_query ): array {
 		// If this is an admin request, or a JSON request with a logged in user, return the posts as normal.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -53,13 +53,11 @@ final class Disable_Deep_Pagination implements Feature {
 		}
 
 		// Set the HTTP response status code to 410.
-		status_header(410);
+		status_header( 410 );
 		// Load the 404 template.
-		include( get_404_template() );
+		include get_404_template();
 		// Terminate the script execution.
 		exit;
-
-		return $where . 'AND 1 = 0';
 	}
 
 	/**

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -62,8 +62,8 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter post results to force page maximum.
 	 *
-	 * @param WP_Post[]    $posts    The posts.
-	 * @param WP_Query $wp_query The WP_Query object, passed by reference.
+	 * @param WP_Post[] $posts    The posts.
+	 * @param WP_Query  $wp_query The WP_Query object, passed by reference.
 	 * @return WP_Post[]
 	 */
 	public static function filter__posts_results( array $posts, WP_Query $wp_query ): array {

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -62,9 +62,9 @@ final class Disable_Deep_Pagination implements Feature {
 	/**
 	 * Filter post results to force max num of pages.
 	 *
-	 * @param WP_Post[] $posts    The posts.
-	 * @param WP_Query  $wp_query The WP_Query object, passed by reference.
-	 * @return WP_Post[]
+	 * @param array<WP_Post> $posts    The posts.
+	 * @param WP_Query       $wp_query The WP_Query object, passed by reference.
+	 * @return array<WP_Post>
 	 */
 	public static function filter__posts_results( array $posts, WP_Query $wp_query ): array {
 		// If this is an admin request, or a JSON request with a logged in user, return the posts as normal.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -52,19 +52,6 @@ final class Disable_Deep_Pagination implements Feature {
 			return $where;
 		}
 
-		// If this is a JSON request, and the user is not logged in, we need to return a 400 error.
-		if ( wp_is_json_request() ) {
-			wp_die(
-				\sprintf(
-					/* translators: The maximum number of pages. */
-					esc_html__( 'Invalid Request: Pagination beyond page %d has been disabled for performance reasons.', 'alley' ),
-					esc_html( $max_pages ),
-				),
-				esc_html__( 'Deep Pagination Disabled', 'alley' ),
-				400
-			);
-		}
-
 		// Set the HTTP response status code to 410.
 		status_header( 410 );
 		// Load the 404 template.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -52,6 +52,19 @@ final class Disable_Deep_Pagination implements Feature {
 			return $where;
 		}
 
+		// If this is a JSON request, and the user is not logged in, we need to return a 400 error.
+		if ( wp_is_json_request() ) {
+			wp_die(
+				\sprintf(
+					/* translators: The maximum number of pages. */
+					esc_html__( 'Invalid Request: Pagination beyond page %d has been disabled for performance reasons.', 'alley' ),
+					esc_html( $max_pages ),
+				),
+				esc_html__( 'Deep Pagination Disabled', 'alley' ),
+				400
+			);
+		}
+
 		// Set the HTTP response status code to 410.
 		status_header( 410 );
 		// Load the 404 template.

--- a/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
+++ b/src/alley/wp/alleyvate/features/class-disable-deep-pagination.php
@@ -58,9 +58,30 @@ final class Disable_Deep_Pagination implements Feature {
 				esc_html( $max_pages ),
 			),
 			esc_html__( 'Deep Pagination Disabled', 'alley' ),
-			400
+			410
 		);
 
 		return $where . 'AND 1 = 0';
+	}
+
+	/**
+	 * Filter the context for the query-pagination-numbers block.
+	 *
+	 * @param array $context The block context.
+	 * @param array $block   The block data.
+	 * @return array
+	 */
+	public static function custom_query_pagination_context( array $context, array $block ): array {
+		global $wp_query;
+
+		// Check if the block is the query-pagination-numbers block.
+		if ( $block['blockName'] === 'core/query-pagination-numbers' ) {
+			// Set the max pages to the value from the query or a default value.
+			$max_pages = ! empty( $wp_query->query['__dangerously_set_max_pages'] ) ? $wp_query->query['__dangerously_set_max_pages'] : 100;
+			// Set the max pages in the context.
+			$context['query']['pages'] = apply_filters( 'alleyvate_deep_pagination_max_pages', $max_pages );
+		}
+
+		return $context;
 	}
 }

--- a/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
@@ -214,7 +214,7 @@ final class DisableDeepPaginationTest extends Test_Case {
 		$this->feature->boot();
 
 		$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
-			->assertStatus( 410 );
+			->assertExactJson( [] );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
 			->get_content();

--- a/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
@@ -213,8 +213,8 @@ final class DisableDeepPaginationTest extends Test_Case {
 	public function test_unauthenticated_rest_queries_are_filtered() {
 		$this->feature->boot();
 
-		// Test for page 101 (should return a 410 response).
-		$this->assertEquals( 410, $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )->get_status() );
+		$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
+			->assertStatus( 410 );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
 			->get_content();

--- a/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
@@ -214,7 +214,7 @@ final class DisableDeepPaginationTest extends Test_Case {
 		$this->feature->boot();
 
 		$this->get( '/wp/v2/posts?per_page=1&page=101' )
-			->assertStatus( 410 );
+			->assertStatus( 404 );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
 			->get_content();

--- a/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
@@ -213,8 +213,8 @@ final class DisableDeepPaginationTest extends Test_Case {
 	public function test_unauthenticated_rest_queries_are_filtered() {
 		$this->feature->boot();
 
-		$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
-			->assertExactJson( [] );
+		// Test for page 101 (should return a 410 response).
+		$this->assertEquals( 410, $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )->get_status() );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
 			->get_content();

--- a/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
@@ -214,7 +214,7 @@ final class DisableDeepPaginationTest extends Test_Case {
 		$this->feature->boot();
 
 		$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
-			->assertExactJson( [] );
+			->assertStatus( 410 );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )
 			->get_content();

--- a/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableDeepPaginationTest.php
@@ -213,7 +213,7 @@ final class DisableDeepPaginationTest extends Test_Case {
 	public function test_unauthenticated_rest_queries_are_filtered() {
 		$this->feature->boot();
 
-		$this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=101' ) )
+		$this->get( '/wp/v2/posts?per_page=1&page=101' )
 			->assertStatus( 410 );
 
 		$body = $this->get_json( rest_url( '/wp/v2/posts?per_page=1&page=100' ) )


### PR DESCRIPTION
## Summary

Ensure that the pagination system never provides links to pages beyond page 100. The number should max out at 100, and if you are on page 100, an “older” link should not display.

If a user attempts to access a page beyond 100, return an HTTP 410 response.

## Notes for reviewers

None.

## Other Information

- [ ] I updated the `README.md` file for any new/updated features.
- [ ] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
