### PR TITLE
Fix conditional check for wp.domReady

### DIFF
--- a/src/alley/wp/alleyvate/features/class-disable-comments.php
+++ b/src/alley/wp/alleyvate/features/class-disable-comments.php
@@ -66,7 +66,7 @@ final class Disable_Comments implements Feature {
 	public static function action__admin_footer(): void {
 		echo "
 			<script>
-			if (typeof wp?.domReady === 'function') {
+			if (wp && typeof wp?.domReady === 'function') {
 				wp.domReady(() => {
 					if (typeof wp?.blocks?.unregisterBlockType === 'function') {
 						// Unregister blocks related to core comments.


### PR DESCRIPTION
Check for `wp` before trying to use `wp`