### PR TITLE
Adds check for block registration before unregistering blocks

### DIFF
--- a/src/alley/wp/alleyvate/features/class-disable-comments.php
+++ b/src/alley/wp/alleyvate/features/class-disable-comments.php
@@ -69,11 +69,18 @@ final class Disable_Comments implements Feature {
 			if (typeof wp !== 'undefined' && typeof wp?.domReady === 'function') {
 				wp.domReady(() => {
 					if (typeof wp?.blocks?.unregisterBlockType === 'function') {
-						// Unregister blocks related to core comments.
-						wp.blocks.unregisterBlockType('core/comments');
-						wp.blocks.unregisterBlockType('core/post-comments-form');
-						wp.blocks.unregisterBlockType('core/comments-query-loop');
-						wp.blocks.unregisterBlockType('core/latest-comments');
+						const blocks = [
+							'core/comments',
+							'core/post-comments-form',
+							'core/comments-query-loop',
+							'core/latest-comments',
+						];
+						blocks.forEach((block) => {
+							if (wp.blocks.getBlockType(block)) {
+								console.log('unregistering');
+								wp.blocks.unregisterBlockType(block);
+							}
+						});
 					}
 				});
 			}

--- a/src/alley/wp/alleyvate/features/class-disable-comments.php
+++ b/src/alley/wp/alleyvate/features/class-disable-comments.php
@@ -77,7 +77,6 @@ final class Disable_Comments implements Feature {
 						];
 						blocks.forEach((block) => {
 							if (wp.blocks.getBlockType(block)) {
-								console.log('unregistering');
 								wp.blocks.unregisterBlockType(block);
 							}
 						});


### PR DESCRIPTION
## Summary

This PR addresses the following issue - https://github.com/alleyinteractive/wp-alleyvate/issues/135

## Notes for reviewers

Just adds a simple check against a block being registered or not before deregistering in this JS snippet. Also pulls the block names into an array and loops over them to DRY things up a bit.

## Other Information

- [ ] I updated the `README.md` file for any new/updated features.
- [ ] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
