### PR TITLE
Fix: Revert disabling the Yoast index completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 3.9.2
+
+### Removed
+* `yoast_performance_enhancements`: No longer disables Yoast SEO Indexables.
+
 ## 3.9.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If one doesn't have a proxy service, one suggestion would be to hook into this f
 
 ### `yoast_performance_enhancements`
 
-Adds a feature to improve Yoast SEO and Yoast SEO Premium performance. Disables the Yoast SEO Indexables feature. Disables the Yoast SEO Premium Prominent words feature.
+Adds a feature to improve Yoast SEO and Yoast SEO Premium performance. Disables the Yoast SEO Premium Prominent words feature.
 
 ## About
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,5 @@ parameters:
 		- wp-alleyvate.php
 
 	ignoreErrors:
-		- '#WP_REST_Request but does not specify its#'
 		- '#Class CoAuthors_Plus not found#'
 		- '#Call to method get_coauthor_by#'

--- a/src/alley/wp/alleyvate/features/class-yoast-performance-enhancements.php
+++ b/src/alley/wp/alleyvate/features/class-yoast-performance-enhancements.php
@@ -24,9 +24,6 @@ final class Yoast_Performance_Enhancements implements Feature {
 	 * Boot the feature.
 	 */
 	public function boot(): void {
-		// Disable the Yoast Indexables feature.
-		add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );
-
 		// Disable the Yoast SEO Premium Prominent Words feature.
 		add_filter( 'Yoast\WP\SEO\prominent_words_post_types', '__return_empty_array' );
 		add_filter( 'Yoast\WP\SEO\prominent_words_taxonomies', '__return_empty_array' );


### PR DESCRIPTION
## Summary

Removes the filter that disables the Yoast index entirely, as it causes unintended consequences for sites using Yoast (e.g., stale data that is pulled from the index but the index is never updated because it is disabled). Keeps the other performance enhancements in that file (prominent words). In the future, we could explore other Yoast performance enhancements that don't involve disabling the index entirely.

## Other Information

- [X] I updated the `README.md` file for any new/updated features.
- [X] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Removed
- Filter that disables the Yoast index completely.

Fixes #154