### PR TITLE
Issue 158: add disable_script_style_concatenation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 3.12.0
+
+### Added
+
+* `disable_script_style_concatenation`: Disables the script and style concatenation (and CSS minification) that WordPress VIP enables by default.
+
 ## 3.11.0
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ which have been shown to force those environments to use an insecure protocol at
 
 This feature disables sending password change notification emails to site admins.
 
+### `disable_script_style_concatenation`
+
+This feature disables the script and style concatenation (and CSS minification) that WordPress VIP enables by default via its [file concatenation and minification](https://docs.wpvip.com/vip-go-mu-plugins/file-concatenation-and-minification/) mu-plugin.
+
+The concatenation produces single, large, rarely cacheable bundles (served from `/_static/??…` URLs) that hurt performance with HTTP/2 enabled and can cause script errors.
+
+This feature has no effect on sites that are not hosted on WordPress VIP.
+
 ### `disable_site_health_directories`
 
 This feature disables the site health check for information about the WordPress directories and their sizes.

--- a/src/alley/wp/alleyvate/features/class-disable-script-style-concatenation.php
+++ b/src/alley/wp/alleyvate/features/class-disable-script-style-concatenation.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Class file for Disable_Script_Style_Concatenation
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Disables the script and style concatenation (and CSS minification) that
+ * WordPress VIP enables by default, which produces single, large, rarely
+ * cacheable bundles that hurt performance on HTTP/2.
+ */
+final class Disable_Script_Style_Concatenation implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_filter( 'js_do_concat', '__return_false' );
+		add_filter( 'css_do_concat', '__return_false' );
+	}
+}

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -125,6 +125,10 @@ function load(): void {
 			'yoast_performance_enhancements',
 			new Features\Yoast_Performance_Enhancements(),
 		),
+		new Feature(
+			'disable_script_style_concatenation',
+			new Features\Disable_Script_Style_Concatenation(),
+		),
 	);
 
 	$plugin->boot();

--- a/tests/Alley/WP/Alleyvate/Features/DisableScriptStyleConcatenationTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/DisableScriptStyleConcatenationTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class file for DisableScriptStyleConcatenationTest
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Test Disable_Script_Style_Concatenation
+ */
+final class DisableScriptStyleConcatenationTest extends Test_Case {
+	/**
+	 * The Feature class.
+	 *
+	 * @var Disable_Script_Style_Concatenation
+	 */
+	protected $feature;
+
+	/**
+	 * Setup before test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->feature = new Disable_Script_Style_Concatenation();
+	}
+
+	/**
+	 * Test that script concatenation is disabled for all script handles.
+	 */
+	public function testScriptConcatenationIsDisabled() {
+		$this->assertTrue( apply_filters( 'js_do_concat', true, 'example-script' ) );
+
+		$this->feature->boot();
+
+		$this->assertFalse( apply_filters( 'js_do_concat', true, 'example-script' ) );
+	}
+
+	/**
+	 * Test that style concatenation is disabled for all style handles.
+	 */
+	public function testStyleConcatenationIsDisabled() {
+		$this->assertTrue( apply_filters( 'css_do_concat', true, 'example-style' ) );
+
+		$this->feature->boot();
+
+		$this->assertFalse( apply_filters( 'css_do_concat', true, 'example-style' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a feature that disables style and script concatenation and minification on WordPress VIP.

Fixes #158.

## Notes for reviewers

None.

## Other Information

- [x] I updated the `README.md` file for any new/updated features.
- [x] I updated the `CHANGELOG.md` file for any new/updated features.

## Changelog entries

### Added

`disable_script_style_concatenation`: Disables the script and style concatenation (and CSS minification) that WordPress VIP enables by default.

### Changed

### Deprecated

### Removed

### Fixed

### Security
