### PR TITLE
Reset theme.json cache on switch_blog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-* `reset_theme_json_cache_on_switch_blog`: Resets `WP_Theme_JSON_Resolver`'s cached data on the `switch_blog` action, fixing global styles rendering with another site's theme.json data for logged-in users on multisite networks.
+* `reset_theme_json_cache_on_switch_blog`: Clears WordPress's cached theme.json data on the `switch_blog` action (via core's own `wp_clean_theme_json_cache()`), fixing global styles rendering with another site's theme.json data for logged-in users on multisite networks.
 
 ## 3.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+* `reset_theme_json_cache_on_switch_blog`: Resets `WP_Theme_JSON_Resolver`'s cached data on the `switch_blog` action, fixing global styles rendering with another site's theme.json data for logged-in users on multisite networks.
+
 ## 3.12.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ sites.
 
 ### `reset_theme_json_cache_on_switch_blog`
 
-This feature resets WordPress's cached theme.json data (`WP_Theme_JSON_Resolver`) whenever the current site changes during a multisite request (i.e., on the `switch_blog` action).
+This feature clears WordPress's cached theme.json data (via core's own `wp_clean_theme_json_cache()`) whenever the current site changes during a multisite request (i.e., on the `switch_blog` action).
 
-`WP_Theme_JSON_Resolver` memoizes its merged theme.json data in static properties for the life of the request, and that cache isn't aware of `switch_to_blog()`/`restore_current_blog()`. On a multisite network, anything that switches into another site mid-request — most notably, WordPress core's admin bar building its "My Sites" menu for a user who belongs to multiple sites — can prime the cache with a different site's resolved data. If that other site's theme.json differs from the current site's (for example, a child theme overriding a font-family preset), the current page ends up rendering global styles using the wrong site's data, but only for logged-in users who see the admin bar.
+WordPress core already hooks `wp_clean_theme_json_cache()` to the `switch_theme` and `start_previewing_theme` actions, since the active theme context changing mid-request can otherwise leave `WP_Theme_JSON_Resolver`'s static cache and the `theme_json` object cache group stale. It isn't hooked to `switch_blog`, though. On a multisite network, anything that switches into another site mid-request — most notably, WordPress core's admin bar building its "My Sites" menu for a user who belongs to multiple sites — can prime these caches with a different site's resolved data. If that other site's theme.json differs from the current site's (for example, a child theme overriding a font-family preset), the current page ends up rendering global styles using the wrong site's data, but only for logged-in users who see the admin bar.
 
 ### `user_enumeration_restrictions`
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ This feature removes the shortlink from the head of the site. By default,
 WordPress adds a shortlink to the head of the site, which is not used by most
 sites.
 
+### `reset_theme_json_cache_on_switch_blog`
+
+This feature resets WordPress's cached theme.json data (`WP_Theme_JSON_Resolver`) whenever the current site changes during a multisite request (i.e., on the `switch_blog` action).
+
+`WP_Theme_JSON_Resolver` memoizes its merged theme.json data in static properties for the life of the request, and that cache isn't aware of `switch_to_blog()`/`restore_current_blog()`. On a multisite network, anything that switches into another site mid-request — most notably, WordPress core's admin bar building its "My Sites" menu for a user who belongs to multiple sites — can prime the cache with a different site's resolved data. If that other site's theme.json differs from the current site's (for example, a child theme overriding a font-family preset), the current page ends up rendering global styles using the wrong site's data, but only for logged-in users who see the admin bar.
+
 ### `user_enumeration_restrictions`
 
 This feature requires users to be logged in before accessing data about registered users that would otherwise be publicly accessible. Its handle is `user_enumeration_restrictions`.

--- a/src/alley/wp/alleyvate/features/class-reset-theme-json-cache-on-switch-blog.php
+++ b/src/alley/wp/alleyvate/features/class-reset-theme-json-cache-on-switch-blog.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Class file for Reset_Theme_Json_Cache_On_Switch_Blog
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Alley\WP\Types\Feature;
+
+/**
+ * Resets WordPress's cached theme.json data whenever the current site changes
+ * in a multisite request.
+ *
+ * `WP_Theme_JSON_Resolver` memoizes its merged theme.json data in static
+ * properties for the life of the request, and `wp_get_global_settings()` /
+ * `wp_get_global_stylesheet()` additionally cache their own return values in
+ * the `theme_json` object cache group. None of this is aware of
+ * `switch_to_blog()`/`restore_current_blog()`, so anything that switches into
+ * another site mid-request (most notably, WordPress core's admin bar building
+ * its "My Sites" menu) can prime these caches with a different site's
+ * resolved data. If that other site's theme.json differs from the current
+ * site's (e.g. a child theme overriding a font-family preset), the current
+ * page's global styles render using the wrong site's data.
+ */
+final class Reset_Theme_Json_Cache_On_Switch_Blog implements Feature {
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_action( 'switch_blog', [ $this, 'clean_cached_data' ] );
+	}
+
+	/**
+	 * Clean WordPress's cached theme.json data so it's recalculated for
+	 * whichever site is current after the switch.
+	 */
+	public function clean_cached_data(): void {
+		if ( class_exists( \WP_Theme_JSON_Resolver::class ) ) {
+			\WP_Theme_JSON_Resolver::clean_cached_data();
+		}
+
+		if ( function_exists( 'wp_cache_flush_group' ) ) {
+			wp_cache_flush_group( 'theme_json' );
+		}
+	}
+}

--- a/src/alley/wp/alleyvate/features/class-reset-theme-json-cache-on-switch-blog.php
+++ b/src/alley/wp/alleyvate/features/class-reset-theme-json-cache-on-switch-blog.php
@@ -18,36 +18,24 @@ use Alley\WP\Types\Feature;
  * Resets WordPress's cached theme.json data whenever the current site changes
  * in a multisite request.
  *
- * `WP_Theme_JSON_Resolver` memoizes its merged theme.json data in static
- * properties for the life of the request, and `wp_get_global_settings()` /
- * `wp_get_global_stylesheet()` additionally cache their own return values in
- * the `theme_json` object cache group. None of this is aware of
- * `switch_to_blog()`/`restore_current_blog()`, so anything that switches into
- * another site mid-request (most notably, WordPress core's admin bar building
- * its "My Sites" menu) can prime these caches with a different site's
- * resolved data. If that other site's theme.json differs from the current
- * site's (e.g. a child theme overriding a font-family preset), the current
- * page's global styles render using the wrong site's data.
+ * WordPress core already hooks its own `wp_clean_theme_json_cache()` (which
+ * resets `WP_Theme_JSON_Resolver`'s static cache along with every known
+ * `theme_json` object cache key) to the `switch_theme` and
+ * `start_previewing_theme` actions, precisely because the active theme
+ * context changing mid-request can otherwise leave these caches stale. It
+ * isn't hooked to `switch_blog`, though, so a multisite network's admin bar
+ * building its "My Sites" menu (which switches into every site the current
+ * user belongs to before the current page's own global styles are
+ * generated) can prime these caches with a different site's resolved data.
+ * If that other site's theme.json differs from the current site's (e.g. a
+ * child theme overriding a font-family preset), the current page's global
+ * styles render using the wrong site's data.
  */
 final class Reset_Theme_Json_Cache_On_Switch_Blog implements Feature {
 	/**
 	 * Boot the feature.
 	 */
 	public function boot(): void {
-		add_action( 'switch_blog', [ $this, 'clean_cached_data' ] );
-	}
-
-	/**
-	 * Clean WordPress's cached theme.json data so it's recalculated for
-	 * whichever site is current after the switch.
-	 */
-	public function clean_cached_data(): void {
-		if ( class_exists( \WP_Theme_JSON_Resolver::class ) ) {
-			\WP_Theme_JSON_Resolver::clean_cached_data();
-		}
-
-		if ( function_exists( 'wp_cache_flush_group' ) ) {
-			wp_cache_flush_group( 'theme_json' );
-		}
+		add_action( 'switch_blog', 'wp_clean_theme_json_cache' );
 	}
 }

--- a/src/alley/wp/alleyvate/load.php
+++ b/src/alley/wp/alleyvate/load.php
@@ -129,6 +129,10 @@ function load(): void {
 			'disable_script_style_concatenation',
 			new Features\Disable_Script_Style_Concatenation(),
 		),
+		new Feature(
+			'reset_theme_json_cache_on_switch_blog',
+			new Features\Reset_Theme_Json_Cache_On_Switch_Blog(),
+		),
 	);
 
 	$plugin->boot();

--- a/tests/Alley/WP/Alleyvate/Features/ResetThemeJsonCacheOnSwitchBlogTest.php
+++ b/tests/Alley/WP/Alleyvate/Features/ResetThemeJsonCacheOnSwitchBlogTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Class file for ResetThemeJsonCacheOnSwitchBlogTest
+ *
+ * (c) Alley <info@alley.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+ *
+ * @package wp-alleyvate
+ */
+
+namespace Alley\WP\Alleyvate\Features;
+
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Test Reset_Theme_Json_Cache_On_Switch_Blog
+ */
+final class ResetThemeJsonCacheOnSwitchBlogTest extends Test_Case {
+	/**
+	 * The Feature class.
+	 *
+	 * @var Reset_Theme_Json_Cache_On_Switch_Blog
+	 */
+	protected $feature;
+
+	/**
+	 * Setup before test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		\WP_Theme_JSON_Resolver::clean_cached_data();
+
+		$this->feature = new Reset_Theme_Json_Cache_On_Switch_Blog();
+	}
+
+	/**
+	 * Clean up after test.
+	 */
+	protected function tearDown(): void {
+		\WP_Theme_JSON_Resolver::clean_cached_data();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that firing `switch_blog` after the feature boots forces theme.json
+	 * to be recalculated, rather than reusing a memoized, stale result.
+	 */
+	public function test_switch_blog_resets_the_cache(): void {
+		// Prime the resolver's cache with the real theme.json data.
+		wp_get_global_settings();
+
+		$inject_test_font_family = fn ( $theme_json ) => $theme_json->update_with(
+			[
+				'version'  => 3,
+				'settings' => [
+					'typography' => [
+						'fontFamilies' => [
+							[
+								'slug'       => 'alleyvate-test',
+								'name'       => 'Alleyvate Test Font',
+								'fontFamily' => 'AlleyvateTestFont, sans-serif',
+							],
+						],
+					],
+				],
+			],
+		);
+
+		add_filter( 'wp_theme_json_data_theme', $inject_test_font_family );
+
+		// Without a cache reset, the memoized data is returned as-is, and the
+		// newly-added filter has no effect yet.
+		$stale_families = wp_list_pluck( $this->get_theme_font_families(), 'fontFamily', 'slug' );
+
+		$this->assertArrayNotHasKey( 'alleyvate-test', $stale_families );
+
+		$this->feature->boot();
+
+		do_action( 'switch_blog', get_current_blog_id(), get_current_blog_id() );
+
+		$fresh_families = wp_list_pluck( $this->get_theme_font_families(), 'fontFamily', 'slug' );
+
+		$this->assertArrayHasKey( 'alleyvate-test', $fresh_families );
+		$this->assertSame( 'AlleyvateTestFont, sans-serif', $fresh_families['alleyvate-test'] );
+
+		remove_filter( 'wp_theme_json_data_theme', $inject_test_font_family );
+	}
+
+	/**
+	 * Get the theme-origin font family definitions from global settings.
+	 *
+	 * @return mixed[]
+	 */
+	private function get_theme_font_families(): array {
+		$settings   = (array) wp_get_global_settings();
+		$typography = (array) ( $settings['typography'] ?? [] );
+		$families   = (array) ( $typography['fontFamilies'] ?? [] );
+
+		return (array) ( $families['theme'] ?? [] );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #164.

`WP_Theme_JSON_Resolver` memoizes its merged theme.json data in static properties for the life of the request, and `wp_get_global_settings()`/`wp_get_global_stylesheet()` (the latter builds `global-styles-inline-css`) each additionally wrap the resolver in their own `theme_json` object-cache group. Neither cache is aware of `switch_to_blog()`/`restore_current_blog()`.

On a multisite network, WordPress core's admin bar builds its "My Sites" menu by switching into every site the current user belongs to — this runs before the current page's own global styles are generated. If another site in that iteration resolves theme.json differently (e.g. a child theme overriding a font-family preset on the current site, but not on that other site), the wrong site's data gets cached and leaks into the current page's render — but only for logged-in users with an admin bar, since anonymous requests never trigger this cross-site iteration.

This adds a new feature, `reset_theme_json_cache_on_switch_blog`, that hooks `switch_blog` and resets:

- `WP_Theme_JSON_Resolver`'s static cache, via its own public `clean_cached_data()` method.
- The `theme_json` object-cache group, via `wp_cache_flush_group()`.

so theme.json is always freshly resolved for whichever site is actually current after any blog switch.

## Test plan

- [x] New test (`ResetThemeJsonCacheOnSwitchBlogTest`) verifies that a filter added to `wp_theme_json_data_theme` after the cache is primed has no effect until `switch_blog` fires with the feature booted, at which point it's picked up.
- [x] `composer phpcs` / `composer phpstan` pass on the new/changed files.
- [x] Full test suite passes (pre-existing, unrelated failures in `CacheSlowQueriesTest` reproduce on `main` too — caused by a PHP 8.4/Mantle-framework deprecation-escalation issue, not this change).