### PR TITLE
Release v3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## 3.13.0
 
 ### Added
 

--- a/wp-alleyvate.php
+++ b/wp-alleyvate.php
@@ -14,7 +14,7 @@
  * Plugin Name: Alleyvate
  * Plugin URI: https://github.com/alleyinteractive/wp-alleyvate
  * Description: Defaults for WordPress sites by Alley
- * Version: 3.12.0
+ * Version: 3.13.0
  * Author: Alley
  * Author URI: https://alley.com
  * Requires at least: 6.2


### PR DESCRIPTION
## Summary

Bumps the version to 3.13.0 in the main plugin file, and renames the CHANGELOG's `Unreleased` heading (added in #165) to `3.13.0` to match convention.